### PR TITLE
feat: increase tree leaf log2 size to 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-008922d5165c764859bc540d7298045eebf5bc60
+          version: nightly-fe2acca4e379793539db80e032d76ffe0110298b
 
       - run: forge build
       - run: forge fmt --check src test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-008922d5165c764859bc540d7298045eebf5bc60
+          version: nightly-fe2acca4e379793539db80e032d76ffe0110298b
 
       - name: Run all tests
         run: make test-all

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test/uarch-log
 *.log
 test/UArchReplay_*.t.sol
 .DS_Store
+tests/*

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_DIR := test
 DOWNLOADDIR := downloads
 SRC_DIR := src
 
-EMULATOR_VERSION ?= v0.17.0
+EMULATOR_VERSION ?= v0.18.0-test4
 
 TESTS_DATA_FILE ?= cartesi-machine-tests-data-$(EMULATOR_VERSION).deb
 TESTS_DATA_DOWNLOAD_URL := https://github.com/cartesi/machine-emulator/releases/download/$(EMULATOR_VERSION)/$(TESTS_DATA_FILE)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_DIR := test
 DOWNLOADDIR := downloads
 SRC_DIR := src
 
-EMULATOR_VERSION ?= v0.18.0-test4
+EMULATOR_VERSION ?= v0.18.0-test5
 
 TESTS_DATA_FILE ?= cartesi-machine-tests-data-$(EMULATOR_VERSION).deb
 TESTS_DATA_DOWNLOAD_URL := https://github.com/cartesi/machine-emulator/releases/download/$(EMULATOR_VERSION)/$(TESTS_DATA_FILE)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_DIR := test
 DOWNLOADDIR := downloads
 SRC_DIR := src
 
-EMULATOR_VERSION ?= v0.18.0-test5
+EMULATOR_VERSION ?= v0.18.0
 
 TESTS_DATA_FILE ?= cartesi-machine-tests-data-$(EMULATOR_VERSION).deb
 TESTS_DATA_DOWNLOAD_URL := https://github.com/cartesi/machine-emulator/releases/download/$(EMULATOR_VERSION)/$(TESTS_DATA_FILE)

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ libs = ["node_modules", "lib"]
 gas_reports = ["*"]
 memory_limit = 11149934592
 fs_permissions = [{access = "read", path = "./test/uarch-log/"}, {access = "read", path = "./test/uarch-bin/"}]
+gas_limit = "18446744073709551615"
 
 [fmt]
 line_length = 80

--- a/helper_scripts/generate_UArchConstants.sh
+++ b/helper_scripts/generate_UArchConstants.sh
@@ -18,9 +18,9 @@ let last=total-end+1
 h=`head -n $start $TEMPLATE_FILE`
 t=`tail -n -$last $TEMPLATE_FILE`
 
-# cd $EMULATOR_DIR
-# make build-emulator-image
-# cd -
+cd $EMULATOR_DIR
+make build-emulator-image
+cd -
 
 # run the Lua script that instantiates the cartesi module and
 # outputs the uarch constants values

--- a/helper_scripts/generate_UArchConstants.sh
+++ b/helper_scripts/generate_UArchConstants.sh
@@ -18,9 +18,9 @@ let last=total-end+1
 h=`head -n $start $TEMPLATE_FILE`
 t=`tail -n -$last $TEMPLATE_FILE`
 
-cd $EMULATOR_DIR
-make build-emulator-image
-cd -
+# cd $EMULATOR_DIR
+# make build-emulator-image
+# cd -
 
 # run the Lua script that instantiates the cartesi module and
 # outputs the uarch constants values

--- a/shasum-download
+++ b/shasum-download
@@ -1,2 +1,2 @@
-e2dcd5598a67844d6a1199189089f2cc9ca306fcb80c45a634376861c89e61de  downloads/cartesi-machine-tests-data-v0.18.0-test5.deb
-d167c42c61a1753190b28461fbe018d4620a2379afc982ed468e3422dd27c8ba  downloads/uarch-riscv-tests-json-logs-v0.18.0-test5.tar.gz
+45acd683f4a8db5ab846150e97857360ba0f44df5c1d787bb18affbcf08c2ace  downloads/cartesi-machine-tests-data-v0.18.0.deb
+016fbbb9d1866399a152f81dbb054447a144445ddc35e91da0a9dd242185463c  downloads/uarch-riscv-tests-json-logs-v0.18.0.tar.gz

--- a/shasum-download
+++ b/shasum-download
@@ -1,2 +1,2 @@
-d3b254f274fd6c32e6688365886fbe6b86f91aab733a83cdb73e2461ed7a0d96  downloads/cartesi-machine-tests-data-v0.17.0.deb
-8f0cd797b78466b62184257b3276d6c029c5ea5a53672036ad507cbf417d0211  downloads/uarch-riscv-tests-json-logs-v0.17.0.tar.gz
+6024a9c7ebf6d10d3721753401c0edd7c3f1392cd26f1cc549fc58d15647a04a  downloads/cartesi-machine-tests-data-v0.18.0-test4.deb
+994af6de340e7efaf024545ddc44e850761115a9be98b82eeec441c869151525  downloads/uarch-riscv-tests-json-logs-v0.18.0-test4.tar.gz

--- a/shasum-download
+++ b/shasum-download
@@ -1,2 +1,2 @@
-6024a9c7ebf6d10d3721753401c0edd7c3f1392cd26f1cc549fc58d15647a04a  downloads/cartesi-machine-tests-data-v0.18.0-test4.deb
-994af6de340e7efaf024545ddc44e850761115a9be98b82eeec441c869151525  downloads/uarch-riscv-tests-json-logs-v0.18.0-test4.tar.gz
+e2dcd5598a67844d6a1199189089f2cc9ca306fcb80c45a634376861c89e61de  downloads/cartesi-machine-tests-data-v0.18.0-test5.deb
+d167c42c61a1753190b28461fbe018d4620a2379afc982ed468e3422dd27c8ba  downloads/uarch-riscv-tests-json-logs-v0.18.0-test5.tar.gz

--- a/src/AccessLogs.sol
+++ b/src/AccessLogs.sol
@@ -62,8 +62,9 @@ library AccessLogs {
         return end2;
     }
 
-    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
-    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
+    /// @dev bytes buffer layout is the different for `readWord` and `writeWord`,
+    /// readWord: [32 bytes as read data], [59 * 32 bytes as sibling hashes]
+    /// writeWord [32 bytes as written hash] [32 bytes as read data], [59 * 32 bytes as sibling hashes]
 
     //
     // Read methods
@@ -95,17 +96,18 @@ library AccessLogs {
         Memory.PhysicalAddress readAddress
     ) internal pure returns (uint64) {
         bytes32 readData = a.buffer.consumeBytes32();
-        bytes32 valHash = keccak256(abi.encodePacked(readData));
-
-        (Memory.PhysicalAddress leafAddress, uint64 offset) =
+        bytes32 computedReadHash = keccak256(abi.encodePacked(readData));
+        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) =
             readAddress.truncateToLeaf();
-        bytes8 readValue = getBytes8FromBytes32AtOffset(readData, offset);
+        bytes8 word = getBytes8FromBytes32AtOffset(readData, wordOffset);
 
-        bytes32 expectedValHash =
+        bytes32 expectedReadHash =
             readLeaf(a, Memory.strideFromLeafAddress(leafAddress));
 
-        require(valHash == expectedValHash, "Read value doesn't match");
-        return machineWordToSolidityUint64(readValue);
+        require(
+            computedReadHash == expectedReadHash, "Read value doesn't match"
+        );
+        return machineWordToSolidityUint64(word);
     }
 
     //
@@ -143,24 +145,28 @@ library AccessLogs {
         Memory.PhysicalAddress writeAddress,
         uint64 newValue
     ) internal pure {
-        bytes32 writtenData = a.buffer.consumeBytes32();
-
-        (Memory.PhysicalAddress leafAddress, uint64 offset) =
+        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) =
             writeAddress.truncateToLeaf();
-        uint64 expectedNewValue = machineWordToSolidityUint64(
-            getBytes8FromBytes32AtOffset(writtenData, offset)
-        );
+        bytes32 writtenHash = a.buffer.consumeBytes32();
+        bytes32 readData = a.buffer.consumeBytes32();
 
+        // check if read data hashes to the same read hash that is next in the buffer
+        bytes32 computedReadHash = keccak256(abi.encodePacked(readData));
+        bytes32 loggedReadHash = a.buffer.peekBytes32();
         require(
-            newValue == expectedNewValue,
-            "Access log value does not contain the expected written value"
+            computedReadHash == loggedReadHash,
+            "logged and computed read hashes mismatch"
         );
 
-        writeLeaf(
-            a,
-            Memory.strideFromLeafAddress(leafAddress),
-            keccak256(abi.encodePacked(writtenData))
+        // construct the written data by patching the verified read data
+        bytes32 computedWrittenData = setBytes8InBytes32AtOffset(
+            readData, wordOffset, solidityUint64ToMachineWord(newValue)
         );
+        bytes32 computedWrittenHash =
+            keccak256(abi.encodePacked(computedWrittenData));
+        require(computedWrittenHash == writtenHash, "Written hash mismatch");
+
+        writeLeaf(a, Memory.strideFromLeafAddress(leafAddress), writtenHash);
     }
 
     function getBytes8FromBytes32AtOffset(bytes32 source, uint64 offset)
@@ -169,5 +175,18 @@ library AccessLogs {
         returns (bytes8)
     {
         return bytes8(source << (offset << Memory.LOG2_WORD));
+    }
+
+    function setBytes8InBytes32AtOffset(
+        bytes32 target,
+        uint64 offset,
+        bytes8 source
+    ) internal pure returns (bytes32) {
+        bytes32 erase_mask = bytes32(bytes8(type(uint64).max));
+        erase_mask = erase_mask >> (offset << Memory.LOG2_WORD);
+        erase_mask = ~erase_mask;
+        bytes32 result = target & erase_mask;
+        result = result | (bytes32(source) >> (offset << Memory.LOG2_WORD));
+        return result;
     }
 }

--- a/src/AccessLogs.sol
+++ b/src/AccessLogs.sol
@@ -61,9 +61,8 @@ library AccessLogs {
         return end2;
     }
 
-    /// @dev bytes buffer layouts differently for `readWord` and `writeWord`,
-    ///`readWord` [8 bytes as uint64 value, 32 bytes as drive hash, 61 * 32 bytes as sibling proofs]
-    ///`writeWord` [32 bytes as old drive hash, 32 * 61 bytes as sibling proofs]
+    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
+    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
 
     //
     // Read methods
@@ -86,7 +85,7 @@ library AccessLogs {
         returns (bytes32)
     {
         Memory.Region memory r =
-            Memory.regionFromStride(readStride, Memory.alignedSizeFromLog2(0));
+            Memory.regionFromStride(readStride, Memory.alignedSizeFromLog2(2));
         return readRegion(a, r);
     }
 
@@ -94,13 +93,21 @@ library AccessLogs {
         AccessLogs.Context memory a,
         Memory.PhysicalAddress readAddress
     ) internal pure returns (uint64) {
-        bytes8 b8 = a.buffer.consumeBytes8();
-        bytes32 valHash = keccak256(abi.encodePacked(b8));
+        bytes32 readData = a.buffer.consumeBytes32();
+        bytes32 valHash = keccak256(abi.encodePacked(readData));
+        Memory.PhysicalAddress leafAddress = Memory.PhysicalAddress.wrap(
+            Memory.PhysicalAddress.unwrap(readAddress) & ~uint64(31)
+        );
+        uint64 offset = Memory.PhysicalAddress.unwrap(readAddress)
+            - Memory.PhysicalAddress.unwrap(leafAddress);
+
+        bytes8 readValue = bytes8(readData << (offset << 3));
+
         bytes32 expectedValHash =
-            readLeaf(a, Memory.strideFromWordAddress(readAddress));
+            readLeaf(a, Memory.strideFromWordAddress(leafAddress));
 
         require(valHash == expectedValHash, "Read value doesn't match");
-        return machineWordToSolidityUint64(b8);
+        return machineWordToSolidityUint64(readValue);
     }
 
     //
@@ -129,7 +136,7 @@ library AccessLogs {
         bytes32 newHash
     ) internal pure {
         Memory.Region memory r =
-            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(0));
+            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(2));
         writeRegion(a, r, newHash);
     }
 
@@ -138,10 +145,25 @@ library AccessLogs {
         Memory.PhysicalAddress writeAddress,
         uint64 newValue
     ) internal pure {
+        bytes32 writtenData = a.buffer.consumeBytes32();
+        Memory.PhysicalAddress leafAddress = Memory.PhysicalAddress.wrap(
+            Memory.PhysicalAddress.unwrap(writeAddress) & ~uint64(31)
+        );
+        uint64 offset = Memory.PhysicalAddress.unwrap(writeAddress)
+            - Memory.PhysicalAddress.unwrap(leafAddress);
+
+        uint64 expectedNewValue =
+            machineWordToSolidityUint64(bytes8(writtenData << (offset << 3)));
+
+        require(
+            newValue == expectedNewValue,
+            "Access log value does not contain the expected written value"
+        );
+
         writeLeaf(
             a,
-            Memory.strideFromWordAddress(writeAddress),
-            keccak256(abi.encodePacked(solidityUint64ToMachineWord(newValue)))
+            Memory.strideFromWordAddress(leafAddress),
+            keccak256(abi.encodePacked(writtenData))
         );
     }
 }

--- a/src/Buffer.sol
+++ b/src/Buffer.sol
@@ -81,10 +81,13 @@ library Buffer {
     ) internal pure returns (bytes32, uint8) {
         // require that multiplier makes sense!
         uint8 logOfSize = region.alignedSize.log2();
-        require(logOfSize <= LOG2RANGE, "Cannot be bigger than the tree itself");
+        require(
+            logOfSize <= Memory.LOG2_MAX_SIZE,
+            "Cannot be bigger than the tree itself"
+        );
 
         uint64 stride = Memory.Stride.unwrap(region.stride);
-        uint8 nodesCount = LOG2RANGE - logOfSize;
+        uint8 nodesCount = Memory.LOG2_MAX_SIZE - logOfSize;
 
         for (uint64 i = 0; i < nodesCount; i++) {
             Buffer.Context memory siblings =
@@ -112,8 +115,6 @@ library Buffer {
 
         return root;
     }
-
-    uint8 constant LOG2RANGE = 61;
 
     function isEven(uint64 x) private pure returns (bool) {
         return x % 2 == 0;

--- a/src/Memory.sol
+++ b/src/Memory.sol
@@ -18,8 +18,8 @@ pragma solidity ^0.8.0;
 library Memory {
     // Specifies a memory region and it's merkle hash.
     // The size is given in the number of leaves in the tree,
-    // and therefore are word-sized.
-    // This means a `alignedSize` specifies a region the size of a word.
+    // and therefore are leaf-sized.
+    // This means a `alignedSize` specifies a region the size of a leaf.
     // The address has to be aligned to a power-of-two.
     // By using an stride, we can guarantee that the address is aligned.
     // The address is given by `stride * (1 << log2s)`.
@@ -45,7 +45,7 @@ library Memory {
         return regionFromStride(stride, alignedSize);
     }
 
-    function regionFromWordAddress(PhysicalAddress startAddress)
+    function regionFromLeafAddress(PhysicalAddress startAddress)
         internal
         pure
         returns (Region memory)
@@ -53,7 +53,6 @@ library Memory {
         return regionFromPhysicalAddress(startAddress, alignedSizeFromLog2(0));
     }
 
-    //
     // Stride and PhysicalAddress
     //
     // When using memory address and a size in merkle trees to refer to a memory region,
@@ -74,23 +73,26 @@ library Memory {
     ) internal pure returns (Stride) {
         uint64 s = alignedSize.size();
         uint64 addr = PhysicalAddress.unwrap(startAddress);
-        // assert memory address is word-aligned (8-byte long)
-        assert(addr & 7 == 0);
-        uint64 position = PhysicalAddress.unwrap(startAddress) >> 3;
+
+        // assert memory address is leaf-aligned (32-byte long)
+        assert(addr & LEAF_MASK == 0);
+        uint64 position = PhysicalAddress.unwrap(startAddress) >> LOG2_LEAF;
+
         // assert position and size are aligned
         // position has to be a multiple of size
         // equivalent to: size = 2^a, position = 2^b, position = size * 2^c, where c >= 0
         assert(((s - 1) & position) == 0);
         uint64 stride = position / s;
+
         return Stride.wrap(stride);
     }
 
-    function strideFromWordAddress(PhysicalAddress startAddress)
+    function strideFromLeafAddress(PhysicalAddress startAddress)
         internal
         pure
         returns (Stride)
     {
-        return strideFromPhysicalAddress(startAddress, alignedSizeFromLog2(2));
+        return strideFromPhysicalAddress(startAddress, alignedSizeFromLog2(0));
     }
 
     function validateStrideLength(Stride stride, AlignedSize alignedSize)
@@ -101,7 +103,6 @@ library Memory {
         assert(Stride.unwrap(stride) * s < MAX_STRIDE);
     }
 
-    //
     // AlignedSize
     //
     // The size is given in the number of leaves in the tree,
@@ -109,7 +110,11 @@ library Memory {
 
     type AlignedSize is uint8;
 
-    uint64 constant MAX_SIZE = (1 << 61);
+    uint8 constant LOG2_WORD = 3;
+    uint8 constant LOG2_LEAF = 5;
+    uint8 constant LOG2_MAX_SIZE = 64 - LOG2_LEAF;
+    uint64 constant LEAF_MASK = uint64(1 << LOG2_LEAF) - 1;
+    uint64 constant MAX_SIZE = uint64(1 << LOG2_MAX_SIZE);
 
     using Memory for AlignedSize;
 
@@ -133,5 +138,25 @@ library Memory {
         returns (PhysicalAddress)
     {
         return PhysicalAddress.wrap(uint64Address);
+    }
+
+    function truncateToLeaf(PhysicalAddress addr)
+        internal
+        pure
+        returns (PhysicalAddress, uint64)
+    {
+        uint64 r = Memory.PhysicalAddress.unwrap(addr) & ~LEAF_MASK;
+        PhysicalAddress truncated = Memory.PhysicalAddress.wrap(r);
+        uint64 offset = minus(addr, truncated);
+        return (truncated, offset);
+    }
+
+    function minus(PhysicalAddress lhs, PhysicalAddress rhs)
+        internal
+        pure
+        returns (uint64)
+    {
+        return Memory.PhysicalAddress.unwrap(lhs)
+            - Memory.PhysicalAddress.unwrap(rhs);
     }
 }

--- a/src/Memory.sol
+++ b/src/Memory.sol
@@ -90,7 +90,7 @@ library Memory {
         pure
         returns (Stride)
     {
-        return strideFromPhysicalAddress(startAddress, alignedSizeFromLog2(0));
+        return strideFromPhysicalAddress(startAddress, alignedSizeFromLog2(2));
     }
 
     function validateStrideLength(Stride stride, AlignedSize alignedSize)

--- a/src/UArchCompat.sol
+++ b/src/UArchCompat.sol
@@ -104,7 +104,7 @@ library UArchCompat {
             Memory.regionFromPhysicalAddress(
                 UArchConstants.RESET_POSITION.toPhysicalAddress(),
                 Memory.alignedSizeFromLog2(
-                    UArchConstants.RESET_ALIGNED_SIZE - 3
+                    UArchConstants.RESET_ALIGNED_SIZE - Memory.LOG2_LEAF
                 )
             ),
             UArchConstants.PRESTINE_STATE

--- a/src/UArchConstants.sol
+++ b/src/UArchConstants.sol
@@ -35,7 +35,7 @@ library UArchConstants {
     uint64 constant RESET_POSITION = 0x400000;
     uint8 constant RESET_ALIGNED_SIZE = 22;
     bytes32 constant PRESTINE_STATE =
-        0xc2b9cf2658f233f44c403aba6e9f9aa6709e00617b349c0190113517f03d13de;
+        0xb0a850996464081741f4eefe12160dd2511514b3d606ec5b9c1b183fbe5a248f;
     uint64 constant UARCH_ECALL_FN_HALT = 1;
     uint64 constant UARCH_ECALL_FN_PUTCHAR = 2;
     // END OF AUTO-GENERATED CODE

--- a/src/UArchConstants.sol
+++ b/src/UArchConstants.sol
@@ -35,7 +35,7 @@ library UArchConstants {
     uint64 constant RESET_POSITION = 0x400000;
     uint8 constant RESET_ALIGNED_SIZE = 22;
     bytes32 constant PRESTINE_STATE =
-        0xb0a850996464081741f4eefe12160dd2511514b3d606ec5b9c1b183fbe5a248f;
+        0x4de6115bdadc23724cf20c5580d718525ce81b294c8c149d3658020c380df109;
     uint64 constant UARCH_ECALL_FN_HALT = 1;
     uint64 constant UARCH_ECALL_FN_PUTCHAR = 2;
     // END OF AUTO-GENERATED CODE

--- a/templates/AccessLogs.sol.template
+++ b/templates/AccessLogs.sol.template
@@ -107,17 +107,22 @@ library AccessLogs {
         AccessLogs.Context memory a,
         Memory.PhysicalAddress readAddress
     ) internal pure returns (uint64) {
-        bytes32 readData = a.buffer.consumeBytes32();
-        bytes32 valHash = keccak256(abi.encodePacked(readData));
+        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) =
+            readAddress.truncateToLeaf();
 
-        (Memory.PhysicalAddress leafAddress, uint64 offset) = readAddress.truncateToLeaf();
-        bytes8 readValue = getBytes8FromBytes32AtOffset(readData, offset);
+        Memory.Region memory region = Memory.regionFromStride(
+            Memory.strideFromLeafAddress(leafAddress),
+            Memory.alignedSizeFromLog2(0)
+        );
 
-        bytes32 expectedValHash =
-            readLeaf(a, Memory.strideFromLeafAddress(leafAddress));
+        bytes32 leaf = a.buffer.consumeBytes32();
+        bytes32 rootHash = a.buffer.getRoot(region, keccak256(abi.encodePacked(leaf)));
+        require(
+            a.currentRootHash == rootHash, "Read word root doesn't match"
+        );
 
-        require(valHash == expectedValHash, "Read value doesn't match");
-        return machineWordToSolidityUint64(readValue);
+        bytes8 word = getBytes8FromBytes32AtOffset(leaf, wordOffset);
+        return machineWordToSolidityUint64(word);
     }
 
     //
@@ -155,7 +160,7 @@ library AccessLogs {
         Memory.PhysicalAddress writeAddress,
         uint64 newValue
     ) internal pure {
-        (Memory.PhysicalAddress leafAddress, uint64 offset) =
+        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) =
             writeAddress.truncateToLeaf();
 
         Memory.Region memory region = Memory.regionFromStride(
@@ -171,7 +176,7 @@ library AccessLogs {
         );
 
         bytes32 newLeaf = setBytes8ToBytes32AtOffset(
-            solidityUint64ToMachineWord(newValue), oldLeaf, offset
+            solidityUint64ToMachineWord(newValue), oldLeaf, wordOffset
         );
 
         bytes32 newRootHash = a.buffer.getRoot(region, keccak256(abi.encodePacked(newLeaf)));

--- a/templates/AccessLogs.sol.template
+++ b/templates/AccessLogs.sol.template
@@ -75,8 +75,9 @@ library AccessLogs {
 
     //:#ifndef test
 
-    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
-    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
+    /// @dev bytes buffer layout is the different for `readWord` and `writeWord`,
+    /// readWord: [32 bytes as read data], [59 * 32 bytes as sibling hashes]
+    /// writeWord [32 bytes as written hash] [32 bytes as read data], [59 * 32 bytes as sibling hashes]
 
     //
     // Read methods
@@ -108,16 +109,15 @@ library AccessLogs {
         Memory.PhysicalAddress readAddress
     ) internal pure returns (uint64) {
         bytes32 readData = a.buffer.consumeBytes32();
-        bytes32 valHash = keccak256(abi.encodePacked(readData));
+        bytes32 computedReadHash = keccak256(abi.encodePacked(readData));
+        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) = readAddress.truncateToLeaf();
+        bytes8 word = getBytes8FromBytes32AtOffset(readData, wordOffset);
 
-        (Memory.PhysicalAddress leafAddress, uint64 offset) = readAddress.truncateToLeaf();
-        bytes8 readValue = getBytes8FromBytes32AtOffset(readData, offset);
-
-        bytes32 expectedValHash =
+        bytes32 expectedReadHash =
             readLeaf(a, Memory.strideFromLeafAddress(leafAddress));
 
-        require(valHash == expectedValHash, "Read value doesn't match");
-        return machineWordToSolidityUint64(readValue);
+        require(computedReadHash == expectedReadHash, "Read value doesn't match");
+        return machineWordToSolidityUint64(word);
     }
 
     //
@@ -155,20 +155,21 @@ library AccessLogs {
         Memory.PhysicalAddress writeAddress,
         uint64 newValue
     ) internal pure {
-        bytes32 writtenData = a.buffer.consumeBytes32();
+        (Memory.PhysicalAddress leafAddress,  uint64 wordOffset) = writeAddress.truncateToLeaf();
+        bytes32 writtenHash = a.buffer.consumeBytes32();
+        bytes32 readData = a.buffer.consumeBytes32();
 
-        (Memory.PhysicalAddress leafAddress,  uint64 offset) = writeAddress.truncateToLeaf();
-        uint64 expectedNewValue =
-            machineWordToSolidityUint64(
-                getBytes8FromBytes32AtOffset(writtenData, offset));
+        // check if read data hashes to the same read hash that is next in the buffer
+        bytes32 computedReadHash = keccak256(abi.encodePacked(readData));
+        bytes32 loggedReadHash = a.buffer.peekBytes32();
+        require(computedReadHash ==loggedReadHash, "logged and computed read hashes mismatch");
 
-        require(newValue == expectedNewValue, "Access log value does not contain the expected written value");
+        // construct the written data by patching the verified read data
+        bytes32 computedWrittenData = setBytes8InBytes32AtOffset(readData, wordOffset, solidityUint64ToMachineWord(newValue));
+        bytes32 computedWrittenHash = keccak256(abi.encodePacked(computedWrittenData));
+        require(computedWrittenHash == writtenHash, "Written hash mismatch");
 
-        writeLeaf(
-            a,
-            Memory.strideFromLeafAddress(leafAddress),
-            keccak256(abi.encodePacked(writtenData))
-        );
+        writeLeaf(a, Memory.strideFromLeafAddress(leafAddress), writtenHash);
     }
 
     function getBytes8FromBytes32AtOffset(bytes32 source, uint64 offset)
@@ -177,6 +178,19 @@ library AccessLogs {
         returns (bytes8)
     {
         return bytes8(source << (offset << Memory.LOG2_WORD));
+    }
+ 
+    function setBytes8InBytes32AtOffset(bytes32 target, uint64 offset, bytes8 source)
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes32 erase_mask = bytes32(bytes8(type(uint64).max));
+        erase_mask = erase_mask >> (offset << Memory.LOG2_WORD);
+        erase_mask = ~erase_mask;
+        bytes32 result = target & erase_mask;
+        result = result | (bytes32(source) >> (offset << Memory.LOG2_WORD));
+        return result;
     }
 
     //:#else

--- a/templates/AccessLogs.sol.template
+++ b/templates/AccessLogs.sol.template
@@ -35,6 +35,7 @@ import "./UArchConstants.sol";
 library AccessLogs {
     using Buffer for Buffer.Context;
     using Memory for Memory.AlignedSize;
+    using Memory for Memory.PhysicalAddress;
 
     struct Context {
         bytes32 currentRootHash;
@@ -98,7 +99,7 @@ library AccessLogs {
         returns (bytes32)
     {
         Memory.Region memory r =
-            Memory.regionFromStride(readStride, Memory.alignedSizeFromLog2(2));
+            Memory.regionFromStride(readStride, Memory.alignedSizeFromLog2(0));
         return readRegion(a, r);
     }
 
@@ -108,13 +109,12 @@ library AccessLogs {
     ) internal pure returns (uint64) {
         bytes32 readData = a.buffer.consumeBytes32();
         bytes32 valHash = keccak256(abi.encodePacked(readData));
-        Memory.PhysicalAddress leafAddress =  Memory.PhysicalAddress.wrap(Memory.PhysicalAddress.unwrap(readAddress) & ~uint64(31));
-        uint64 offset = Memory.PhysicalAddress.unwrap(readAddress) - Memory.PhysicalAddress.unwrap(leafAddress);
-        
-        bytes8 readValue = bytes8(readData << (offset << 3));
+
+        (Memory.PhysicalAddress leafAddress, uint64 offset) = readAddress.truncateToLeaf();
+        bytes8 readValue = getBytes8FromBytes32AtOffset(readData, offset);
 
         bytes32 expectedValHash =
-            readLeaf(a, Memory.strideFromWordAddress(leafAddress));
+            readLeaf(a, Memory.strideFromLeafAddress(leafAddress));
 
         require(valHash == expectedValHash, "Read value doesn't match");
         return machineWordToSolidityUint64(readValue);
@@ -146,7 +146,7 @@ library AccessLogs {
         bytes32 newHash
     ) internal pure {
         Memory.Region memory r =
-            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(2));
+            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(0));
         writeRegion(a, r, newHash);
     }
 
@@ -156,18 +156,27 @@ library AccessLogs {
         uint64 newValue
     ) internal pure {
         bytes32 writtenData = a.buffer.consumeBytes32();
-        Memory.PhysicalAddress leafAddress =  Memory.PhysicalAddress.wrap(Memory.PhysicalAddress.unwrap(writeAddress) & ~uint64(31));
-        uint64 offset = Memory.PhysicalAddress.unwrap(writeAddress) - Memory.PhysicalAddress.unwrap(leafAddress);
-        
-        uint64 expectedNewValue = machineWordToSolidityUint64(bytes8(writtenData << (offset << 3)));
+
+        (Memory.PhysicalAddress leafAddress,  uint64 offset) = writeAddress.truncateToLeaf();
+        uint64 expectedNewValue =
+            machineWordToSolidityUint64(
+                getBytes8FromBytes32AtOffset(writtenData, offset));
 
         require(newValue == expectedNewValue, "Access log value does not contain the expected written value");
 
         writeLeaf(
             a,
-            Memory.strideFromWordAddress(leafAddress),
+            Memory.strideFromLeafAddress(leafAddress),
             keccak256(abi.encodePacked(writtenData))
         );
+    }
+
+    function getBytes8FromBytes32AtOffset(bytes32 source, uint64 offset)
+        internal
+        pure
+        returns (bytes8)
+    {
+        return bytes8(source << (offset << Memory.LOG2_WORD));
     }
 
     //:#else

--- a/templates/AccessLogs.sol.template
+++ b/templates/AccessLogs.sol.template
@@ -74,9 +74,8 @@ library AccessLogs {
 
     //:#ifndef test
 
-    /// @dev bytes buffer layouts differently for `readWord` and `writeWord`,
-    ///`readWord` [8 bytes as uint64 value, 32 bytes as drive hash, 61 * 32 bytes as sibling proofs]
-    ///`writeWord` [32 bytes as old drive hash, 32 * 61 bytes as sibling proofs]
+    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
+    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
 
     //
     // Read methods
@@ -99,7 +98,7 @@ library AccessLogs {
         returns (bytes32)
     {
         Memory.Region memory r =
-            Memory.regionFromStride(readStride, Memory.alignedSizeFromLog2(0));
+            Memory.regionFromStride(readStride, Memory.alignedSizeFromLog2(2));
         return readRegion(a, r);
     }
 
@@ -107,13 +106,18 @@ library AccessLogs {
         AccessLogs.Context memory a,
         Memory.PhysicalAddress readAddress
     ) internal pure returns (uint64) {
-        bytes8 b8 = a.buffer.consumeBytes8();
-        bytes32 valHash = keccak256(abi.encodePacked(b8));
+        bytes32 readData = a.buffer.consumeBytes32();
+        bytes32 valHash = keccak256(abi.encodePacked(readData));
+        Memory.PhysicalAddress leafAddress =  Memory.PhysicalAddress.wrap(Memory.PhysicalAddress.unwrap(readAddress) & ~uint64(31));
+        uint64 offset = Memory.PhysicalAddress.unwrap(readAddress) - Memory.PhysicalAddress.unwrap(leafAddress);
+        
+        bytes8 readValue = bytes8(readData << (offset << 3));
+
         bytes32 expectedValHash =
-            readLeaf(a, Memory.strideFromWordAddress(readAddress));
+            readLeaf(a, Memory.strideFromWordAddress(leafAddress));
 
         require(valHash == expectedValHash, "Read value doesn't match");
-        return machineWordToSolidityUint64(b8);
+        return machineWordToSolidityUint64(readValue);
     }
 
     //
@@ -142,7 +146,7 @@ library AccessLogs {
         bytes32 newHash
     ) internal pure {
         Memory.Region memory r =
-            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(0));
+            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(2));
         writeRegion(a, r, newHash);
     }
 
@@ -151,10 +155,18 @@ library AccessLogs {
         Memory.PhysicalAddress writeAddress,
         uint64 newValue
     ) internal pure {
+        bytes32 writtenData = a.buffer.consumeBytes32();
+        Memory.PhysicalAddress leafAddress =  Memory.PhysicalAddress.wrap(Memory.PhysicalAddress.unwrap(writeAddress) & ~uint64(31));
+        uint64 offset = Memory.PhysicalAddress.unwrap(writeAddress) - Memory.PhysicalAddress.unwrap(leafAddress);
+        
+        uint64 expectedNewValue = machineWordToSolidityUint64(bytes8(writtenData << (offset << 3)));
+
+        require(newValue == expectedNewValue, "Access log value does not contain the expected written value");
+
         writeLeaf(
             a,
-            Memory.strideFromWordAddress(writeAddress),
-            keccak256(abi.encodePacked(solidityUint64ToMachineWord(newValue)))
+            Memory.strideFromWordAddress(leafAddress),
+            keccak256(abi.encodePacked(writtenData))
         );
     }
 

--- a/templates/AccessLogs.sol.template
+++ b/templates/AccessLogs.sol.template
@@ -75,9 +75,8 @@ library AccessLogs {
 
     //:#ifndef test
 
-    /// @dev bytes buffer layout is the different for `readWord` and `writeWord`,
-    /// readWord: [32 bytes as read data], [59 * 32 bytes as sibling hashes]
-    /// writeWord [32 bytes as written hash] [32 bytes as read data], [59 * 32 bytes as sibling hashes]
+    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
+    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
 
     //
     // Read methods
@@ -109,15 +108,16 @@ library AccessLogs {
         Memory.PhysicalAddress readAddress
     ) internal pure returns (uint64) {
         bytes32 readData = a.buffer.consumeBytes32();
-        bytes32 computedReadHash = keccak256(abi.encodePacked(readData));
-        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) = readAddress.truncateToLeaf();
-        bytes8 word = getBytes8FromBytes32AtOffset(readData, wordOffset);
+        bytes32 valHash = keccak256(abi.encodePacked(readData));
 
-        bytes32 expectedReadHash =
+        (Memory.PhysicalAddress leafAddress, uint64 offset) = readAddress.truncateToLeaf();
+        bytes8 readValue = getBytes8FromBytes32AtOffset(readData, offset);
+
+        bytes32 expectedValHash =
             readLeaf(a, Memory.strideFromLeafAddress(leafAddress));
 
-        require(computedReadHash == expectedReadHash, "Read value doesn't match");
-        return machineWordToSolidityUint64(word);
+        require(valHash == expectedValHash, "Read value doesn't match");
+        return machineWordToSolidityUint64(readValue);
     }
 
     //
@@ -155,21 +155,27 @@ library AccessLogs {
         Memory.PhysicalAddress writeAddress,
         uint64 newValue
     ) internal pure {
-        (Memory.PhysicalAddress leafAddress,  uint64 wordOffset) = writeAddress.truncateToLeaf();
-        bytes32 writtenHash = a.buffer.consumeBytes32();
-        bytes32 readData = a.buffer.consumeBytes32();
+        (Memory.PhysicalAddress leafAddress, uint64 offset) =
+            writeAddress.truncateToLeaf();
 
-        // check if read data hashes to the same read hash that is next in the buffer
-        bytes32 computedReadHash = keccak256(abi.encodePacked(readData));
-        bytes32 loggedReadHash = a.buffer.peekBytes32();
-        require(computedReadHash ==loggedReadHash, "logged and computed read hashes mismatch");
+        Memory.Region memory region = Memory.regionFromStride(
+            Memory.strideFromLeafAddress(leafAddress),
+            Memory.alignedSizeFromLog2(0)
+        );
 
-        // construct the written data by patching the verified read data
-        bytes32 computedWrittenData = setBytes8InBytes32AtOffset(readData, wordOffset, solidityUint64ToMachineWord(newValue));
-        bytes32 computedWrittenHash = keccak256(abi.encodePacked(computedWrittenData));
-        require(computedWrittenHash == writtenHash, "Written hash mismatch");
+        bytes32 oldLeaf = a.buffer.consumeBytes32();
+        (bytes32 rootHash,) = a.buffer.peekRoot(region, keccak256(abi.encodePacked(oldLeaf)));
 
-        writeLeaf(a, Memory.strideFromLeafAddress(leafAddress), writtenHash);
+        require(
+            a.currentRootHash == rootHash, "Write word root doesn't match"
+        );
+
+        bytes32 newLeaf = setBytes8ToBytes32AtOffset(
+            solidityUint64ToMachineWord(newValue), oldLeaf, offset
+        );
+
+        bytes32 newRootHash = a.buffer.getRoot(region, keccak256(abi.encodePacked(newLeaf)));
+        a.currentRootHash = newRootHash;
     }
 
     function getBytes8FromBytes32AtOffset(bytes32 source, uint64 offset)
@@ -179,19 +185,21 @@ library AccessLogs {
     {
         return bytes8(source << (offset << Memory.LOG2_WORD));
     }
- 
-    function setBytes8InBytes32AtOffset(bytes32 target, uint64 offset, bytes8 source)
+
+    function setBytes8ToBytes32AtOffset(bytes8 word, bytes32 leaf, uint64 offset)
         internal
         pure
         returns (bytes32)
     {
-        bytes32 erase_mask = bytes32(bytes8(type(uint64).max));
-        erase_mask = erase_mask >> (offset << Memory.LOG2_WORD);
-        erase_mask = ~erase_mask;
-        bytes32 result = target & erase_mask;
-        result = result | (bytes32(source) >> (offset << Memory.LOG2_WORD));
-        return result;
+        uint256 wordOffset = offset << Memory.LOG2_WORD;
+        bytes32 toWrite = bytes32(word) >> wordOffset;
+
+        bytes32 wordMask = bytes32(~bytes8(0));
+        bytes32 mask = ~(wordMask >> wordOffset);
+
+        return (leaf & mask) | toWrite;
     }
+
 
     //:#else
 

--- a/templates/UArchReplay.t.sol.template
+++ b/templates/UArchReplay.t.sol.template
@@ -33,7 +33,7 @@ contract UArchReplay_@X@_Test is Test {
     string constant JSON_PATH = "./test/uarch-log/";
     string constant CATALOG_PATH = "catalog.json";
 
-    uint256 constant siblingsLength = 61;
+    uint256 constant siblingsLength = 59;
 
     struct Entry {
         string binaryFilename;
@@ -84,12 +84,10 @@ contract UArchReplay_@X@_Test is Test {
                 vm.parseBytes32(string.concat("0x", catalog[i].initialRootHash));
             bytes32 finalRootHash =
                 vm.parseBytes32(string.concat("0x", catalog[i].finalRootHash));
-
             for (uint256 j = 0; j < catalog[i].steps; j++) {
                 console.log("Replaying step %d ...", j);
                 // load json log
                 loadBufferFromRawJson(buffer, rj, j);
-
                 AccessLogs.Context memory accessLogs = AccessLogs.Context(
                     initialRootHash, Buffer.Context(buffer, 0)
                 );
@@ -140,20 +138,14 @@ contract UArchReplay_@X@_Test is Test {
         Buffer.Context memory buffer = Buffer.Context(data, 0);
 
         for (uint256 i = 0; i < arrayLength; i++) {
-            if (
-                keccak256(abi.encodePacked(rawAccesses[i].typeAccess))
-                    == keccak256(abi.encodePacked("read"))
-            ) {
-                bytes8 word = bytes8(
-                    vm.parseBytes(string.concat("0x", rawAccesses[i].value))
-                );
-                buffer.writeBytes8(word);
-            }
+            bytes32 word = bytes32(
+                vm.parseBytes32(string.concat("0x", rawAccesses[i].value))
+            );
+            buffer.writeBytes32(word);
 
             buffer.writeBytes32(
                 vm.parseBytes32(string.concat("0x", rawAccesses[i].read_hash))
             );
-
             for (uint256 j = 0; j < siblingsLength; j++) {
                 buffer.writeBytes32(
                     vm.parseBytes32(

--- a/templates/UArchReplay.t.sol.template
+++ b/templates/UArchReplay.t.sol.template
@@ -47,12 +47,12 @@ contract UArchReplay_@X@_Test is Test {
 
     struct RawAccess {
         uint256 addressAccess;
-        string hash;
         uint256 log2_size;
         string read_hash;
+        string read_value;
         string[] sibling_hashes;
         string typeAccess;
-        string value;
+        string written_hash;
     }
 
     function testReplay_@X@() public {
@@ -91,7 +91,6 @@ contract UArchReplay_@X@_Test is Test {
                 AccessLogs.Context memory accessLogs = AccessLogs.Context(
                     initialRootHash, Buffer.Context(buffer, 0)
                 );
-
                 // initialRootHash is passed and will be updated through out the step
                 UArchStep.step(accessLogs);
                 initialRootHash = accessLogs.currentRootHash;
@@ -138,8 +137,16 @@ contract UArchReplay_@X@_Test is Test {
         Buffer.Context memory buffer = Buffer.Context(data, 0);
 
         for (uint256 i = 0; i < arrayLength; i++) {
+            if (
+                keccak256(abi.encodePacked(rawAccesses[i].typeAccess))
+                    == keccak256(abi.encodePacked("write"))
+            ) {
+                buffer.writeBytes32(
+                    vm.parseBytes32(string.concat("0x", rawAccesses[i].written_hash))
+                );
+            }
             bytes32 word = bytes32(
-                vm.parseBytes32(string.concat("0x", rawAccesses[i].value))
+                vm.parseBytes32(string.concat("0x", rawAccesses[i].read_value))
             );
             buffer.writeBytes32(word);
 

--- a/templates/UArchReplay.t.sol.template
+++ b/templates/UArchReplay.t.sol.template
@@ -137,22 +137,16 @@ contract UArchReplay_@X@_Test is Test {
         Buffer.Context memory buffer = Buffer.Context(data, 0);
 
         for (uint256 i = 0; i < arrayLength; i++) {
-            if (
-                keccak256(abi.encodePacked(rawAccesses[i].typeAccess))
-                    == keccak256(abi.encodePacked("write"))
-            ) {
+            if (rawAccesses[i].log2_size == 3) {
                 buffer.writeBytes32(
-                    vm.parseBytes32(string.concat("0x", rawAccesses[i].written_hash))
+                    vm.parseBytes32(string.concat("0x", rawAccesses[i].read_value))
+                );
+            } else {
+                buffer.writeBytes32(
+                    vm.parseBytes32(string.concat("0x", rawAccesses[i].read_hash))
                 );
             }
-            bytes32 word = bytes32(
-                vm.parseBytes32(string.concat("0x", rawAccesses[i].read_value))
-            );
-            buffer.writeBytes32(word);
 
-            buffer.writeBytes32(
-                vm.parseBytes32(string.concat("0x", rawAccesses[i].read_hash))
-            );
             for (uint256 j = 0; j < siblingsLength; j++) {
                 buffer.writeBytes32(
                     vm.parseBytes32(

--- a/test/AccessLogs.t.sol
+++ b/test/AccessLogs.t.sol
@@ -147,8 +147,8 @@ contract AccessLogsTest is Test {
     {
         bytes32 b32 = makeLeaf(word, position);
         Buffer.Context memory buffer =
-            Buffer.Context(new bytes((59 << 5) + 32 + 32), 0);
-        buffer.writeBytes32(b32); // leaf containing the readd word
+            Buffer.Context(new bytes((59 << Memory.LOG2_LEAF) + 32 + 32), 0);
+        buffer.writeBytes32(b32); // leaf containing the read word
 
         for (uint256 i = 0; i < 60; i++) {
             buffer.writeBytes32(hashes[i]);
@@ -170,7 +170,8 @@ contract AccessLogsTest is Test {
     }
 
     function rootFromHashes(bytes32 drive) private view returns (bytes32) {
-        Buffer.Context memory buffer = Buffer.Context(new bytes(59 << 5), 0);
+        Buffer.Context memory buffer =
+            Buffer.Context(new bytes(59 << Memory.LOG2_LEAF), 0);
 
         for (uint256 i = 0; i < 59; i++) {
             buffer.writeBytes32(hashes[i + 1]);
@@ -180,8 +181,8 @@ contract AccessLogsTest is Test {
         buffer.offset = 0;
         (bytes32 root,) = buffer.peekRoot(
             Memory.regionFromStride(
-                Memory.strideFromWordAddress(position.toPhysicalAddress()),
-                Memory.alignedSizeFromLog2(2)
+                Memory.strideFromLeafAddress(position.toPhysicalAddress()),
+                Memory.alignedSizeFromLog2(0)
             ),
             drive
         );

--- a/test/Memory.t.sol
+++ b/test/Memory.t.sol
@@ -28,7 +28,7 @@ contract MemoryTest is Test {
 
     function testStrideAlignment() public {
         for (uint128 paddr = 8; paddr <= (1 << 63); paddr *= 2) {
-            for (uint8 l = 0; ((1 << l) <= (paddr >> 3)); ++l) {
+            for (uint8 l = 0; ((1 << l) <= (paddr >> Memory.LOG2_LEAF)); ++l) {
                 uint64(paddr).toPhysicalAddress().strideFromPhysicalAddress(
                     Memory.alignedSizeFromLog2(l)
                 );
@@ -39,7 +39,7 @@ contract MemoryTest is Test {
                     Memory.alignedSizeFromLog2(l)
                 );
 
-                if ((1 << l) == (paddr >> 3)) {
+                if ((1 << l) == (paddr >> Memory.LOG2_LEAF)) {
                     // address has to be aligned with stride size
                     vm.expectRevert();
                     uint64(paddr + paddr / 2).toPhysicalAddress()

--- a/test/UArchReset.t.sol
+++ b/test/UArchReset.t.sol
@@ -48,12 +48,13 @@ contract UArchReset_Test is Test {
     }
 
     struct RawAccess {
-        uint256 position;
-        string hash;
-        uint256 log2Size;
-        string readHash;
-        string[] rawSiblings;
-        string accessType;
+        uint256 addressAccess;
+        uint256 log2_size;
+        string read_hash;
+        string read_value;
+        string[] sibling_hashes;
+        string typeAccess;
+        string written_hash;
     }
     // string val; omit val because it's not used in reset
 
@@ -137,30 +138,30 @@ contract UArchReset_Test is Test {
         Buffer.Context memory buffer = Buffer.Context(data, 0);
 
         if (
-            keccak256(abi.encodePacked(rawAccesses[0].accessType))
+            keccak256(abi.encodePacked(rawAccesses[0].typeAccess))
                 == keccak256(abi.encodePacked("read"))
         ) {
             revert("should'nt have read access in reset");
         }
         assertEq(
-            rawAccesses[0].position,
+            rawAccesses[0].addressAccess,
             UArchConstants.RESET_POSITION,
             "position should be (0x400000)"
         );
         assertEq(
-            rawAccesses[0].log2Size,
+            rawAccesses[0].log2_size,
             UArchConstants.RESET_ALIGNED_SIZE,
             "log2Size should be 22"
         );
 
         buffer.writeBytes32(
-            vm.parseBytes32(string.concat("0x", rawAccesses[0].readHash))
+            vm.parseBytes32(string.concat("0x", rawAccesses[0].read_hash))
         );
 
         for (uint256 i = 0; i < siblingsLength; i++) {
             buffer.writeBytes32(
                 vm.parseBytes32(
-                    string.concat("0x", rawAccesses[0].rawSiblings[i])
+                    string.concat("0x", rawAccesses[0].sibling_hashes[i])
                 )
             );
         }


### PR DESCRIPTION
This branch updates access logs handling and tests according to the emulator changes introduced in this PR:

https://github.com/cartesi/machine-emulator/pull/259

In the emulator, the Merkle tree word size is increased from 8 to 32 bytes.

The access log format has changed as follows:

- The value field is now 32 bytes long and contains the Merkle tree leaf where the accessed word is located.
- To locate the relevant 64-bit word inside data, we compute the offset of address relative to the leaf-aligned address.
- The sibling_hashes field now has 59 entries.
