### PR TITLE
Fix tests

### DIFF
--- a/test/EmulatorCompat.t.sol
+++ b/test/EmulatorCompat.t.sol
@@ -19,6 +19,12 @@ import "src/EmulatorCompat.sol";
 
 pragma solidity ^0.8.0;
 
+library ExternalEmulatorCompat {
+    function uint32Log2(uint32 value) external pure returns (uint32) {
+        return EmulatorCompat.uint32Log2(value);
+    }
+}
+
 contract EmulatorCompatTest is Test {
     int16 constant INT16_MAX = type(int16).max;
     int32 constant INT32_MAX = type(int32).max;
@@ -156,6 +162,6 @@ contract EmulatorCompatTest is Test {
 
     function testUint32Log2Of0() public {
         vm.expectRevert("EmulatorCompat: log2(0) is undefined");
-        EmulatorCompat.uint32Log2(0);
+        ExternalEmulatorCompat.uint32Log2(0);
     }
 }

--- a/test/UArchInterpret.t.sol
+++ b/test/UArchInterpret.t.sol
@@ -22,6 +22,16 @@ import "src/EmulatorConstants.sol";
 
 pragma solidity ^0.8.0;
 
+library ExternalUArchInterpret {
+    function interpret(AccessLogs.Context memory accessLogs)
+        external
+        pure
+        returns (UArchStep.UArchStepStatus)
+    {
+        return UArchInterpret.interpret(accessLogs);
+    }
+}
+
 contract UArchInterpretTest is Test {
     using stdJson for string;
     using Memory for uint64;
@@ -131,7 +141,7 @@ contract UArchInterpretTest is Test {
         EmulatorCompat.writeCycle(a, 0);
 
         vm.expectRevert("illegal instruction");
-        UArchInterpret.interpret(a);
+        ExternalUArchInterpret.interpret(a);
     }
 
     function loadBin(Buffer.Context memory buffer, string memory path)


### PR DESCRIPTION
- Add `TransitionState.sol` which exposes `step`, `reset` and `sendCmio` as external functions. This give us better modularity, smaller code size, and better testability.
- Also fixed some tests with newer foundry version.