### PR TITLE
make the prototype node work with the 0.20.0 emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_DIR := test
 DOWNLOADDIR := downloads
 SRC_DIR := src
 
-EMULATOR_VERSION ?= v0.19.0
+EMULATOR_VERSION ?= v0.20.0-test
 EMULATOR_TAG ?=
 
 TESTS_DATA_FILE ?= machine-emulator-tests-data.deb

--- a/helper_scripts/generate_EmulatorConstants.lua
+++ b/helper_scripts/generate_EmulatorConstants.lua
@@ -15,8 +15,7 @@ end
 
 local out = io.stdout
 
-
-
+out:write('    bytes32 constant UARCH_PRISTINE_STATE_HASH = 0x' .. hexstring(cartesi.UARCH_PRISTINE_STATE_HASH) .. ';\n')
 out:write('    uint64 constant UARCH_CYCLE_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("uarch_cycle")) .. ';\n')
 out:write('    uint64 constant UARCH_HALT_FLAG_ADDRESS = 0x' ..
     hex(cartesi.machine:get_reg_address("uarch_halt_flag")) .. ';\n')
@@ -27,22 +26,28 @@ out:write('    uint64 constant UARCH_SHADOW_LENGTH = 0x' .. hex(cartesi.UARCH_SH
 out:write('    uint64 constant UARCH_RAM_START_ADDRESS = 0x' .. hex(cartesi.UARCH_RAM_START_ADDRESS) .. ';\n')
 out:write('    uint64 constant UARCH_RAM_LENGTH = 0x' .. hex(cartesi.UARCH_RAM_LENGTH) .. ';\n')
 out:write('    uint64 constant UARCH_STATE_START_ADDRESS = 0x' .. hex(cartesi.UARCH_STATE_START_ADDRESS) .. ';\n')
-out:write('    uint8 constant UARCH_STATE_LOG2_SIZE = ' .. cartesi.UARCH_STATE_LOG2_SIZE .. ';\n')
-out:write('    bytes32 constant UARCH_PRISTINE_STATE_HASH = 0x' .. hexstring(cartesi.UARCH_PRISTINE_STATE_HASH) .. ';\n')
 out:write('    uint64 constant UARCH_ECALL_FN_HALT = ' .. cartesi.UARCH_ECALL_FN_HALT .. ';\n')
 out:write('    uint64 constant UARCH_ECALL_FN_PUTCHAR = ' .. cartesi.UARCH_ECALL_FN_PUTCHAR .. ';\n')
 out:write('    uint64 constant HTIF_YIELD = 0x' .. hex(cartesi.machine:get_reg_address("htif_iyield")) .. ';\n')
 out:write('    uint64 constant IFLAGS_Y_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("iflags_Y")) .. ';\n')
 out:write('    uint64 constant HTIF_FROMHOST_ADDRESS = 0x' ..
     hex(cartesi.machine:get_reg_address("htif_fromhost")) .. ';\n')
-out:write('    uint8 constant CMIO_YIELD_REASON_ADVANCE_STATE = 0x' ..
-    hex(cartesi.CMIO_YIELD_REASON_ADVANCE_STATE) .. ';\n')
+out:write('    uint64 constant HTIF_TOHOST_ADDRESS = 0x' ..
+    hex(cartesi.machine:get_reg_address("htif_tohost")) .. ';\n')
+out:write('    uint64 constant PMA_CMIO_TX_BUFFER_START = 0x' .. hex(cartesi.PMA_CMIO_TX_BUFFER_START) .. ';\n')
+out:write('    uint64 constant PMA_CMIO_RX_BUFFER_START = 0x' .. hex(cartesi.PMA_CMIO_RX_BUFFER_START) .. ';\n')
 out:write('    uint32 constant TREE_LOG2_WORD_SIZE = 0x' .. hex(cartesi.TREE_LOG2_WORD_SIZE) .. ';\n')
 out:write('    uint32 constant TREE_WORD_SIZE = uint32(1) << TREE_LOG2_WORD_SIZE;\n')
-out:write('    uint64 constant PMA_CMIO_RX_BUFFER_START = 0x' .. hex(cartesi.PMA_CMIO_RX_BUFFER_START) .. ';\n')
-out:write('    uint8 constant PMA_CMIO_RX_BUFFER_LOG2_SIZE = 0x' .. hex(cartesi.PMA_CMIO_RX_BUFFER_LOG2_SIZE) .. ';\n')
-out:write('    uint64 constant PMA_CMIO_TX_BUFFER_START = 0x' .. hex(cartesi.PMA_CMIO_TX_BUFFER_START) .. ';\n')
+out:write('    uint16 constant CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED = 0x' ..
+    hex(cartesi.CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED) .. ';\n')
+out:write('    uint16 constant CMIO_YIELD_MANUAL_REASON_RX_REJECTED = 0x' ..
+    hex(cartesi.CMIO_YIELD_MANUAL_REASON_RX_REJECTED) .. ';\n')
+out:write('    uint16 constant CMIO_YIELD_MANUAL_REASON_TX_EXCEPTION = 0x' ..
+    hex(cartesi.CMIO_YIELD_MANUAL_REASON_TX_EXCEPTION) .. ';\n')
+out:write('    uint8 constant UARCH_STATE_LOG2_SIZE = ' .. cartesi.UARCH_STATE_LOG2_SIZE .. ';\n')
 out:write('    uint8 constant PMA_CMIO_TX_BUFFER_LOG2_SIZE = 0x' .. hex(cartesi.PMA_CMIO_TX_BUFFER_LOG2_SIZE) .. ';\n')
-out:close()
+out:write('    uint8 constant PMA_CMIO_RX_BUFFER_LOG2_SIZE = 0x' .. hex(cartesi.PMA_CMIO_RX_BUFFER_LOG2_SIZE) .. ';\n')
+out:write('    uint8 constant CMIO_YIELD_REASON_ADVANCE_STATE = 0x' ..
+    hex(cartesi.CMIO_YIELD_REASON_ADVANCE_STATE) .. ';\n')
 
 out:close()

--- a/helper_scripts/generate_EmulatorConstants.lua
+++ b/helper_scripts/generate_EmulatorConstants.lua
@@ -17,26 +17,33 @@ local out = io.stdout
 
 out:write('    bytes32 constant UARCH_PRISTINE_STATE_HASH = 0x' .. hexstring(cartesi.UARCH_PRISTINE_STATE_HASH) .. ';\n')
 out:write('    uint64 constant UARCH_CYCLE_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("uarch_cycle")) .. ';\n')
+out:write('    uint64 constant UARCH_CYCLE_MAX = 0x' .. hex(cartesi.UARCH_CYCLE_MAX) .. ';\n')
 out:write('    uint64 constant UARCH_HALT_FLAG_ADDRESS = 0x' ..
     hex(cartesi.machine:get_reg_address("uarch_halt_flag")) .. ';\n')
 out:write('    uint64 constant UARCH_PC_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("uarch_pc")) .. ';\n')
 out:write('    uint64 constant UARCH_X0_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("uarch_x0")) .. ';\n')
 out:write('    uint64 constant UARCH_SHADOW_START_ADDRESS = 0x' .. hex(cartesi.UARCH_SHADOW_START_ADDRESS) .. ';\n')
 out:write('    uint64 constant UARCH_SHADOW_LENGTH = 0x' .. hex(cartesi.UARCH_SHADOW_LENGTH) .. ';\n')
+out:write('    uint64 constant AR_SHADOW_TLB_START = 0x' .. hex(cartesi.AR_SHADOW_TLB_START) .. ';\n')
+out:write('    uint64 constant AR_SHADOW_TLB_LENGTH = 0x' .. hex(cartesi.AR_SHADOW_TLB_LENGTH) .. ';\n')
 out:write('    uint64 constant UARCH_RAM_START_ADDRESS = 0x' .. hex(cartesi.UARCH_RAM_START_ADDRESS) .. ';\n')
 out:write('    uint64 constant UARCH_RAM_LENGTH = 0x' .. hex(cartesi.UARCH_RAM_LENGTH) .. ';\n')
 out:write('    uint64 constant UARCH_STATE_START_ADDRESS = 0x' .. hex(cartesi.UARCH_STATE_START_ADDRESS) .. ';\n')
 out:write('    uint64 constant UARCH_ECALL_FN_HALT = ' .. cartesi.UARCH_ECALL_FN_HALT .. ';\n')
 out:write('    uint64 constant UARCH_ECALL_FN_PUTCHAR = ' .. cartesi.UARCH_ECALL_FN_PUTCHAR .. ';\n')
+out:write('    uint64 constant UARCH_ECALL_FN_MARK_DIRTY_PAGE = ' .. cartesi.UARCH_ECALL_FN_MARK_DIRTY_PAGE .. ';\n')
+out:write('    uint64 constant UARCH_ECALL_FN_WRITE_TLB = ' .. cartesi.UARCH_ECALL_FN_WRITE_TLB .. ';\n')
 out:write('    uint64 constant HTIF_YIELD = 0x' .. hex(cartesi.machine:get_reg_address("htif_iyield")) .. ';\n')
 out:write('    uint64 constant IFLAGS_Y_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("iflags_Y")) .. ';\n')
 out:write('    uint64 constant HTIF_FROMHOST_ADDRESS = 0x' ..
     hex(cartesi.machine:get_reg_address("htif_fromhost")) .. ';\n')
 out:write('    uint64 constant HTIF_TOHOST_ADDRESS = 0x' ..
     hex(cartesi.machine:get_reg_address("htif_tohost")) .. ';\n')
-out:write('    uint64 constant PMA_CMIO_TX_BUFFER_START = 0x' .. hex(cartesi.PMA_CMIO_TX_BUFFER_START) .. ';\n')
-out:write('    uint64 constant PMA_CMIO_RX_BUFFER_START = 0x' .. hex(cartesi.PMA_CMIO_RX_BUFFER_START) .. ';\n')
-out:write('    uint32 constant TREE_LOG2_WORD_SIZE = 0x' .. hex(cartesi.TREE_LOG2_WORD_SIZE) .. ';\n')
+out:write('    uint64 constant AR_CMIO_TX_BUFFER_START = 0x' .. hex(cartesi.AR_CMIO_TX_BUFFER_START) .. ';\n')
+out:write('    uint64 constant AR_CMIO_RX_BUFFER_START = 0x' .. hex(cartesi.AR_CMIO_RX_BUFFER_START) .. ';\n')
+out:write('    uint8 constant AR_CMIO_TX_BUFFER_LOG2_SIZE = 0x' .. hex(cartesi.AR_CMIO_TX_BUFFER_LOG2_SIZE) .. ';\n')
+out:write('    uint8 constant AR_CMIO_RX_BUFFER_LOG2_SIZE = 0x' .. hex(cartesi.AR_CMIO_RX_BUFFER_LOG2_SIZE) .. ';\n')
+out:write('    uint32 constant TREE_LOG2_WORD_SIZE = 0x' .. hex(cartesi.HASH_TREE_LOG2_WORD_SIZE) .. ';\n')
 out:write('    uint32 constant TREE_WORD_SIZE = uint32(1) << TREE_LOG2_WORD_SIZE;\n')
 out:write('    uint16 constant CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED = 0x' ..
     hex(cartesi.CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED) .. ';\n')
@@ -45,9 +52,9 @@ out:write('    uint16 constant CMIO_YIELD_MANUAL_REASON_RX_REJECTED = 0x' ..
 out:write('    uint16 constant CMIO_YIELD_MANUAL_REASON_TX_EXCEPTION = 0x' ..
     hex(cartesi.CMIO_YIELD_MANUAL_REASON_TX_EXCEPTION) .. ';\n')
 out:write('    uint8 constant UARCH_STATE_LOG2_SIZE = ' .. cartesi.UARCH_STATE_LOG2_SIZE .. ';\n')
-out:write('    uint8 constant PMA_CMIO_TX_BUFFER_LOG2_SIZE = 0x' .. hex(cartesi.PMA_CMIO_TX_BUFFER_LOG2_SIZE) .. ';\n')
-out:write('    uint8 constant PMA_CMIO_RX_BUFFER_LOG2_SIZE = 0x' .. hex(cartesi.PMA_CMIO_RX_BUFFER_LOG2_SIZE) .. ';\n')
 out:write('    uint8 constant CMIO_YIELD_REASON_ADVANCE_STATE = 0x' ..
     hex(cartesi.CMIO_YIELD_REASON_ADVANCE_STATE) .. ';\n')
+out:write('    uint32 constant HASH_TREE_LOG2_WORD_SIZE = 0x' .. hex(cartesi.HASH_TREE_LOG2_WORD_SIZE) .. ';\n')
+out:write('    uint32 constant HASH_TREE_WORD_SIZE = uint32(1) << HASH_TREE_LOG2_WORD_SIZE;\n')
 
 out:close()

--- a/helper_scripts/generate_SendCmioResponse.sh
+++ b/helper_scripts/generate_SendCmioResponse.sh
@@ -38,9 +38,9 @@ cpp_src=`echo "${BASH_REMATCH[1]}" \
         | $SED "/Explicit instantiatio/d" \
         | $SED "/template/d" \
         | $SED "/    uint32 length);/d" \
-        | $SED "s/machine_merkle_tree::get_log2_word_size()/TREE_LOG2_WORD_SIZE/g" \
+        | $SED "s/machine_merkle_tree::get_log2_word_size()/HASH_TREE_LOG2_WORD_SIZE/g" \
         | $SED -E "s/($COMPAT_FNS)/EmulatorCompat.\1/g" \
-        | $SED "s/writeMemoryWithPadding(a, PMA_CMIO_RX_BUFFER_START, data, dataLength, writeLengthLog2Size);/a.writeRegion(Memory.regionFromPhysicalAddress(PMA_CMIO_RX_BUFFER_START.toPhysicalAddress(),Memory.alignedSizeFromLog2(uint8(writeLengthLog2Size - TREE_LOG2_WORD_SIZE))),dataHash);"/g \
+        | $SED "s/writeMemoryWithPadding(a, AR_CMIO_RX_BUFFER_START, data, dataLength, writeLengthLog2Size);/a.writeRegion(Memory.regionFromPhysicalAddress(AR_CMIO_RX_BUFFER_START.toPhysicalAddress(),Memory.alignedSizeFromLog2(uint8(writeLengthLog2Size - HASH_TREE_LOG2_WORD_SIZE))),dataHash);"/g \
         | $SED -E "s/($CONSTANTS)([^a-zA-Z])/EmulatorConstants.\1\2/g" \
         | $SED "s/void send_cmio_response(STATE_ACCESS a, uint16 reason, bytes data, uint32 dataLength) {/function sendCmioResponse(AccessLogs.Context memory a, uint16 reason, bytes32 dataHash, uint32 dataLength) internal pure {/" \
         | $SED "s/const uint64/uint64/g" \

--- a/helper_scripts/generate_UArchStep.sh
+++ b/helper_scripts/generate_UArchStep.sh
@@ -45,10 +45,10 @@ pattern="namespace cartesi \{(.*)\}"
 # replace cpp specific syntaxes with solidity ones
 cpp_src=`echo "${BASH_REMATCH[1]}" \
         | $SED "/template/d" \
-        | $SED "/note = a.make_scoped_note/d" \
+        | $SED "/[[maybe_unused]]/d" \
         | $SED "/(void) note/d" \
         | $SED "s/constexpr//g" \
-        | $SED "s/UarchState &a/AccessLogs.Context memory a/g" \
+        | $SED "s/const UarchState a/AccessLogs.Context memory a/g" \
         | $SED "s/::/./g" \
         | $SED "s/UINT64_MAX/type(uint64).max/g" \
         | $SED -E "s/UArchStepStatus uarch_step/static inline UArchStepStatus step/g" \

--- a/shasum-download
+++ b/shasum-download
@@ -1,2 +1,2 @@
-127e5430d6ca80c65f1943d2b72fe4fd0b970f444376cf6f8663f3ace496f5ff  downloads/machine-emulator-tests-data.deb
-154e2da0e3bb531a8b6e1f9ec64cb90a55cea245aeece2685aa34378d1cf9ea1  downloads/uarch-riscv-tests-json-logs.tar.gz
+6d8d7124d21023ab122e1a6dfb6bea6200a5ae1f622757a8a205cab509ee364a  downloads/machine-emulator-tests-data.deb
+a3560debe80e2f29968d19c4a4a37d6aa4428014a42829563a65d4107e8f1241  downloads/uarch-riscv-tests-json-logs.tar.gz

--- a/src/AccessLogs.sol
+++ b/src/AccessLogs.sol
@@ -169,20 +169,20 @@ library AccessLogs {
         a.currentRootHash = newRootHash;
     }
 
-    function getBytes8FromBytes32AtOffset(bytes32 source, uint64 offset)
+    function getBytes8FromBytes32AtOffset(bytes32 source, uint64 offsetInBytes)
         internal
         pure
         returns (bytes8)
     {
-        return bytes8(source << (offset << Memory.LOG2_WORD));
+        return bytes8(source << (offsetInBytes << Memory.LOG2_WORD));
     }
 
     function setBytes8ToBytes32AtOffset(
         bytes8 word,
         bytes32 leaf,
-        uint64 offset
+        uint64 offsetInBytes
     ) internal pure returns (bytes32) {
-        uint256 wordOffset = offset << Memory.LOG2_WORD;
+        uint256 wordOffset = offsetInBytes << Memory.LOG2_WORD;
         bytes32 toWrite = bytes32(word) >> wordOffset;
 
         bytes32 wordMask = bytes32(~bytes8(0));

--- a/src/AccessLogs.sol
+++ b/src/AccessLogs.sol
@@ -62,12 +62,6 @@ library AccessLogs {
         return end2;
     }
 
-    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
-    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
-
-    //
-    // Read methods
-    //
     function readRegion(
         AccessLogs.Context memory a,
         Memory.Region memory region
@@ -90,30 +84,6 @@ library AccessLogs {
         return readRegion(a, r);
     }
 
-    function readWord(
-        AccessLogs.Context memory a,
-        Memory.PhysicalAddress readAddress
-    ) internal pure returns (uint64) {
-        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) =
-            readAddress.truncateToLeaf();
-
-        Memory.Region memory region = Memory.regionFromStride(
-            Memory.strideFromLeafAddress(leafAddress),
-            Memory.alignedSizeFromLog2(0)
-        );
-
-        bytes32 leaf = a.buffer.consumeBytes32();
-        bytes32 rootHash =
-            a.buffer.getRoot(region, keccak256(abi.encodePacked(leaf)));
-        require(a.currentRootHash == rootHash, "Read word root doesn't match");
-
-        bytes8 word = getBytes8FromBytes32AtOffset(leaf, wordOffset);
-        return machineWordToSolidityUint64(word);
-    }
-
-    //
-    // Write methods
-    //
     function writeRegion(
         AccessLogs.Context memory a,
         Memory.Region memory region,
@@ -141,6 +111,36 @@ library AccessLogs {
         writeRegion(a, r, newHash);
     }
 
+    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
+    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
+
+    //
+    // Read methods
+    //
+    function readWord(
+        AccessLogs.Context memory a,
+        Memory.PhysicalAddress readAddress
+    ) internal pure returns (uint64) {
+        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) =
+            readAddress.truncateToLeaf();
+
+        Memory.Region memory region = Memory.regionFromStride(
+            Memory.strideFromLeafAddress(leafAddress),
+            Memory.alignedSizeFromLog2(0)
+        );
+
+        bytes32 leaf = a.buffer.consumeBytes32();
+        bytes32 rootHash =
+            a.buffer.getRoot(region, keccak256(abi.encodePacked(leaf)));
+        require(a.currentRootHash == rootHash, "Read word root doesn't match");
+
+        bytes8 word = getBytes8FromBytes32AtOffset(leaf, wordOffset);
+        return machineWordToSolidityUint64(word);
+    }
+
+    //
+    // Write methods
+    //
     function writeWord(
         AccessLogs.Context memory a,
         Memory.PhysicalAddress writeAddress,

--- a/src/AccessLogs.sol
+++ b/src/AccessLogs.sol
@@ -62,6 +62,75 @@ library AccessLogs {
         return end2;
     }
 
+    function writeRegion(
+        AccessLogs.Context memory a,
+        Memory.Region memory region,
+        bytes32 newHash
+    ) internal pure {
+        bytes32 oldDrive = a.buffer.consumeBytes32();
+        (bytes32 rootHash,) = a.buffer.peekRoot(region, oldDrive);
+
+        require(
+            a.currentRootHash == rootHash, "Write region root doesn't match"
+        );
+
+        bytes32 newRootHash = a.buffer.getRoot(region, newHash);
+
+        a.currentRootHash = newRootHash;
+    }
+
+    /// @notice Writes 4 64-bit words (32 bytes total) to a single leaf in memory
+    /// @dev This function is specifically designed for writing TLB entries and similar structures
+    function write4Words(
+        AccessLogs.Context memory a,
+        Memory.Stride writeStride,
+        uint64 word0,
+        uint64 word1,
+        uint64 word2,
+        uint64 word3
+    ) internal pure {
+        // Flip endianess and pack data
+        bytes8 w0 = solidityUint64ToMachineWord(word0);
+        bytes8 w1 = solidityUint64ToMachineWord(word1);
+        bytes8 w2 = solidityUint64ToMachineWord(word2);
+        bytes8 w3 = solidityUint64ToMachineWord(word3);
+        bytes32 packed = bytes32(abi.encodePacked(w0, w1, w2, w3));
+
+        // Compute the physical address from stride
+        // For a single leaf, alignedSize = 0, so address = stride << LOG2_LEAF
+        uint64 physicalAddress =
+            Memory.Stride.unwrap(writeStride) << Memory.LOG2_LEAF;
+        Memory.PhysicalAddress paddr = Memory.toPhysicalAddress(physicalAddress);
+
+        // Find the offset in the access log buffer that corresponds to the physical address
+        accessWord(a, paddr);
+        bytes memory data = a.buffer.data;
+        uint256 offset = a.buffer.offset;
+
+        // Update the access log buffer
+        // The 32 is added to offset because we are accessing a byte array.
+        // And an array in solidity always starts with its length which is a 32 byte-long variable.
+        assembly {
+            mstore(add(data, add(offset, 32)), packed)
+        }
+    }
+
+    function writeLeaf(
+        AccessLogs.Context memory a,
+        Memory.Stride writeStride,
+        bytes32 newHash
+    ) internal pure {
+        Memory.Region memory r =
+            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(0));
+        writeRegion(a, r, newHash);
+    }
+
+    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
+    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
+
+    //
+    // Read methods
+    //
     function readRegion(
         AccessLogs.Context memory a,
         Memory.Region memory region
@@ -84,39 +153,6 @@ library AccessLogs {
         return readRegion(a, r);
     }
 
-    function writeRegion(
-        AccessLogs.Context memory a,
-        Memory.Region memory region,
-        bytes32 newHash
-    ) internal pure {
-        bytes32 oldDrive = a.buffer.consumeBytes32();
-        (bytes32 rootHash,) = a.buffer.peekRoot(region, oldDrive);
-
-        require(
-            a.currentRootHash == rootHash, "Write region root doesn't match"
-        );
-
-        bytes32 newRootHash = a.buffer.getRoot(region, newHash);
-
-        a.currentRootHash = newRootHash;
-    }
-
-    function writeLeaf(
-        AccessLogs.Context memory a,
-        Memory.Stride writeStride,
-        bytes32 newHash
-    ) internal pure {
-        Memory.Region memory r =
-            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(0));
-        writeRegion(a, r, newHash);
-    }
-
-    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
-    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
-
-    //
-    // Read methods
-    //
     function readWord(
         AccessLogs.Context memory a,
         Memory.PhysicalAddress readAddress
@@ -141,6 +177,7 @@ library AccessLogs {
     //
     // Write methods
     //
+
     function writeWord(
         AccessLogs.Context memory a,
         Memory.PhysicalAddress writeAddress,
@@ -169,25 +206,60 @@ library AccessLogs {
         a.currentRootHash = newRootHash;
     }
 
-    function getBytes8FromBytes32AtOffset(bytes32 source, uint64 offsetInBytes)
+    function getBytes8FromBytes32AtOffset(bytes32 source, uint64 offset)
         internal
         pure
         returns (bytes8)
     {
-        return bytes8(source << (offsetInBytes << Memory.LOG2_WORD));
+        return bytes8(source << (offset << Memory.LOG2_WORD));
     }
 
     function setBytes8ToBytes32AtOffset(
         bytes8 word,
         bytes32 leaf,
-        uint64 offsetInBytes
+        uint64 offset
     ) internal pure returns (bytes32) {
-        uint256 wordOffset = offsetInBytes << Memory.LOG2_WORD;
+        uint256 wordOffset = offset << Memory.LOG2_WORD;
         bytes32 toWrite = bytes32(word) >> wordOffset;
 
         bytes32 wordMask = bytes32(~bytes8(0));
         bytes32 mask = ~(wordMask >> wordOffset);
 
         return (leaf & mask) | toWrite;
+    }
+
+    function accessWord(
+        AccessLogs.Context memory a,
+        Memory.PhysicalAddress paddr
+    ) private pure returns (bytes32 val) {
+        uint64 index;
+        uint64 position = Memory.PhysicalAddress.unwrap(paddr);
+        if (
+            position >= EmulatorConstants.AR_SHADOW_TLB_START
+                && position
+                    <= EmulatorConstants.AR_SHADOW_TLB_START
+                        + EmulatorConstants.AR_SHADOW_TLB_LENGTH
+        ) {
+            index =
+                position - EmulatorConstants.AR_SHADOW_TLB_START;
+        } else if (
+            position >= EmulatorConstants.UARCH_SHADOW_START_ADDRESS
+                && position
+                    <= EmulatorConstants.UARCH_SHADOW_START_ADDRESS
+                        + EmulatorConstants.UARCH_SHADOW_LENGTH
+        ) {
+            index =
+                (position - EmulatorConstants.UARCH_SHADOW_START_ADDRESS)
+                    + EmulatorConstants.AR_SHADOW_TLB_LENGTH;
+        } else if (position >= EmulatorConstants.UARCH_RAM_START_ADDRESS) {
+            index = (position - EmulatorConstants.UARCH_RAM_START_ADDRESS)
+                + EmulatorConstants.AR_SHADOW_TLB_LENGTH
+                + EmulatorConstants.UARCH_SHADOW_LENGTH;
+        } else {
+            revert("invalid memory access");
+        }
+
+        a.buffer.offset = index;
+        val = a.buffer.peekBytes32();
     }
 }

--- a/src/AdvanceStatus.sol
+++ b/src/AdvanceStatus.sol
@@ -22,15 +22,22 @@ pragma solidity ^0.8.0;
 import "./EmulatorCompat.sol";
 import "./EmulatorConstants.sol";
 
-enum Status {
-    NOT_YIELDED,
-    ACCEPTED,
-    REJECTED,
-    EXCEPTION
-}
-
 library AdvanceStatus {
-    // START OF AUTO-GENERATED CODE
+    enum Status {
+        NOT_YIELDED,
+        ACCEPTED,
+        REJECTED,
+        EXCEPTION
+    }
+
+    /*
+    typedef struct cmt_io_yield {
+    uint8_t dev;
+    uint8_t cmd;
+    uint16_t reason;
+    uint32_t data;
+    } cmt_io_yield_t;
+    */
 
     function advanceStatus(AccessLogs.Context memory a)
         internal
@@ -40,6 +47,11 @@ library AdvanceStatus {
         if (!EmulatorCompat.readIflagsY(a)) {
             return Status.NOT_YIELDED;
         }
+
+        // the following two approaches are equivalent:
+        // 1. swap the whole struct and then extract the reason
+        // 2. extract the reason from the struct and then swap the value
+        // EmulatorCompat.readWord already swaps the struct, so we can extract the reason directly
 
         uint64 tohost =
             EmulatorCompat.readWord(a, EmulatorConstants.HTIF_TOHOST_ADDRESS);
@@ -59,6 +71,4 @@ library AdvanceStatus {
             revert("Invalid reason");
         }
     }
-
-    // END OF AUTO-GENERATED CODE
 }

--- a/src/AdvanceStatus.sol
+++ b/src/AdvanceStatus.sol
@@ -39,6 +39,8 @@ library AdvanceStatus {
     } cmt_io_yield_t;
     */
 
+    error InvalidReason(uint16 reason);
+
     function advanceStatus(AccessLogs.Context memory a)
         internal
         pure
@@ -55,7 +57,7 @@ library AdvanceStatus {
 
         uint64 tohost =
             EmulatorCompat.readWord(a, EmulatorConstants.HTIF_TOHOST_ADDRESS);
-        uint16 reason = uint16((tohost >> 16) & ((1 << 16) - 1));
+        uint16 reason = uint16(tohost >> 32);
 
         if (reason == EmulatorConstants.CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED) {
             return Status.ACCEPTED;
@@ -68,7 +70,7 @@ library AdvanceStatus {
         ) {
             return Status.EXCEPTION;
         } else {
-            revert("Invalid reason");
+            revert InvalidReason(reason);
         }
     }
 }

--- a/src/AdvanceStatus.sol
+++ b/src/AdvanceStatus.sol
@@ -1,0 +1,64 @@
+// Copyright Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/// @title AdvanceStatus
+/// @notice Return advance status
+
+pragma solidity ^0.8.0;
+
+import "./EmulatorCompat.sol";
+import "./EmulatorConstants.sol";
+
+enum Status {
+    NOT_YIELDED,
+    ACCEPTED,
+    REJECTED,
+    EXCEPTION
+}
+
+library AdvanceStatus {
+    // START OF AUTO-GENERATED CODE
+
+    function advanceStatus(AccessLogs.Context memory a)
+        internal
+        pure
+        returns (Status)
+    {
+        if (!EmulatorCompat.readIflagsY(a)) {
+            return Status.NOT_YIELDED;
+        }
+
+        uint64 tohost =
+            EmulatorCompat.readWord(a, EmulatorConstants.HTIF_TOHOST_ADDRESS);
+        uint16 reason = uint16((tohost >> 16) & ((1 << 16) - 1));
+
+        if (reason == EmulatorConstants.CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED) {
+            return Status.ACCEPTED;
+        } else if (
+            reason == EmulatorConstants.CMIO_YIELD_MANUAL_REASON_RX_REJECTED
+        ) {
+            return Status.REJECTED;
+        } else if (
+            reason == EmulatorConstants.CMIO_YIELD_MANUAL_REASON_TX_EXCEPTION
+        ) {
+            return Status.EXCEPTION;
+        } else {
+            revert("Invalid reason");
+        }
+    }
+
+    // END OF AUTO-GENERATED CODE
+}

--- a/src/EmulatorCompat.sol
+++ b/src/EmulatorCompat.sol
@@ -34,7 +34,9 @@ library EmulatorCompat {
                 EmulatorConstants.CHECKPOINT_ADDRESS.toPhysicalAddress()
             )
         );
-        assert(keccak256(abi.encodePacked(checkpointHash)) == hashOfCheckpointHash);
+        require(
+            keccak256(abi.encodePacked(checkpointHash)) == hashOfCheckpointHash
+        );
 
         return checkpointHash;
     }

--- a/src/EmulatorCompat.sol
+++ b/src/EmulatorCompat.sol
@@ -20,6 +20,7 @@ import "./AccessLogs.sol";
 
 library EmulatorCompat {
     using AccessLogs for AccessLogs.Context;
+    using Buffer for Buffer.Context;
     using Memory for uint64;
 
     function getCheckpointHash(AccessLogs.Context memory a)
@@ -27,11 +28,15 @@ library EmulatorCompat {
         pure
         returns (bytes32)
     {
-        return a.readLeaf(
+        bytes32 checkpointHash = a.buffer.consumeBytes32();
+        bytes32 hashOfCheckpointHash = a.readLeaf(
             Memory.strideFromLeafAddress(
-                EmulatorConstants.checkpointAddress.toPhysicalAddress()
+                EmulatorConstants.CHECKPOINT_ADDRESS.toPhysicalAddress()
             )
         );
+        assert(keccak256(abi.encodePacked(checkpointHash)) == hashOfCheckpointHash);
+
+        return checkpointHash;
     }
 
     function readCycle(AccessLogs.Context memory a)
@@ -102,13 +107,13 @@ library EmulatorCompat {
 
     function setCheckpointHash(
         AccessLogs.Context memory a,
-        bytes32 checkPointHash
+        bytes32 checkpointHash
     ) internal pure {
         a.writeLeaf(
             Memory.strideFromLeafAddress(
-                EmulatorConstants.checkpointAddress.toPhysicalAddress()
+                EmulatorConstants.CHECKPOINT_ADDRESS.toPhysicalAddress()
             ),
-            checkPointHash
+            keccak256(abi.encodePacked(checkpointHash))
         );
     }
 

--- a/src/EmulatorCompat.sol
+++ b/src/EmulatorCompat.sol
@@ -22,6 +22,18 @@ library EmulatorCompat {
     using AccessLogs for AccessLogs.Context;
     using Memory for uint64;
 
+    function getCheckpointHash(AccessLogs.Context memory a)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return a.readLeaf(
+            Memory.strideFromLeafAddress(
+                EmulatorConstants.checkpointAddress.toPhysicalAddress()
+            )
+        );
+    }
+
     function readCycle(AccessLogs.Context memory a)
         internal
         pure
@@ -85,6 +97,18 @@ library EmulatorCompat {
     function setHaltFlag(AccessLogs.Context memory a) internal pure {
         a.writeWord(
             EmulatorConstants.UARCH_HALT_FLAG_ADDRESS.toPhysicalAddress(), 1
+        );
+    }
+
+    function setCheckpointHash(
+        AccessLogs.Context memory a,
+        bytes32 checkPointHash
+    ) internal pure {
+        a.writeLeaf(
+            Memory.strideFromLeafAddress(
+                EmulatorConstants.checkpointAddress.toPhysicalAddress()
+            ),
+            checkPointHash
         );
     }
 

--- a/src/EmulatorCompat.sol
+++ b/src/EmulatorCompat.sol
@@ -54,12 +54,19 @@ library EmulatorCompat {
     function readHaltFlag(AccessLogs.Context memory a)
         internal
         pure
-        returns (bool)
+        returns (uint64)
     {
-        return (
-            a.readWord(
-                EmulatorConstants.UARCH_HALT_FLAG_ADDRESS.toPhysicalAddress()
-            ) != 0
+        return a.readWord(
+            EmulatorConstants.UARCH_HALT_FLAG_ADDRESS.toPhysicalAddress()
+        );
+    }
+
+    function writeHaltFlag(AccessLogs.Context memory a, uint64 val)
+        internal
+        pure
+    {
+        a.writeWord(
+            EmulatorConstants.UARCH_HALT_FLAG_ADDRESS.toPhysicalAddress(), val
         );
     }
 
@@ -68,8 +75,9 @@ library EmulatorCompat {
         pure
         returns (uint64)
     {
-        return
-            a.readWord(EmulatorConstants.UARCH_PC_ADDRESS.toPhysicalAddress());
+        return a.readWord(
+            EmulatorConstants.UARCH_PC_ADDRESS.toPhysicalAddress()
+        );
     }
 
     function readWord(AccessLogs.Context memory a, uint64 paddr)
@@ -92,18 +100,9 @@ library EmulatorCompat {
         return a.readWord(paddr.toPhysicalAddress());
     }
 
-    function writeCycle(AccessLogs.Context memory a, uint64 val)
-        internal
-        pure
-    {
+    function writeCycle(AccessLogs.Context memory a, uint64 val) internal pure {
         a.writeWord(
             EmulatorConstants.UARCH_CYCLE_ADDRESS.toPhysicalAddress(), val
-        );
-    }
-
-    function setHaltFlag(AccessLogs.Context memory a) internal pure {
-        a.writeWord(
-            EmulatorConstants.UARCH_HALT_FLAG_ADDRESS.toPhysicalAddress(), 1
         );
     }
 
@@ -158,8 +157,9 @@ library EmulatorCompat {
         pure
         returns (bool)
     {
-        uint64 iflags_y =
-            a.readWord(EmulatorConstants.IFLAGS_Y_ADDRESS.toPhysicalAddress());
+        uint64 iflags_y = a.readWord(
+            EmulatorConstants.IFLAGS_Y_ADDRESS.toPhysicalAddress()
+        );
         if (iflags_y == 0) {
             return false;
         }
@@ -311,7 +311,40 @@ library EmulatorCompat {
         revert(text);
     }
 
-    function putChar(AccessLogs.Context memory a, uint8 c) internal pure {}
+    function putCharECALL(AccessLogs.Context memory a, uint8 c) internal pure {}
+
+    function markDirtyPageECALL(
+        AccessLogs.Context memory a,
+        uint64 paddr,
+        uint64 pma_index
+    ) internal pure {}
+
+    function writeTlbECALL(
+        AccessLogs.Context memory a,
+        uint64 setIndex,
+        uint64 slotIndex,
+        uint64 vaddrPage,
+        uint64 vpOffset,
+        uint64 pmaIindex
+    ) internal pure {
+        // compute physical address of the TLB slot
+        uint64 paddress = EmulatorConstants.AR_SHADOW_TLB_START
+            + (setIndex * EmulatorConstants.TLB_SET_LENGTH)
+            + (slotIndex * EmulatorConstants.TLB_SLOT_LENGTH);
+
+        // compute stride from physical address (stride = address / leaf_size)
+        Memory.Stride writeStride =
+            Memory.strideFromLeafAddress(paddress.toPhysicalAddress());
+
+        // write the 4 words
+        a.write4Words(
+            writeStride,
+            vaddrPage,
+            vpOffset,
+            pmaIindex,
+            0 // zero_padding_
+        );
+    }
 
     function uint32Log2(uint32 value) internal pure returns (uint32) {
         require(value > 0, "EmulatorCompat: log2(0) is undefined");

--- a/src/EmulatorConstants.sol
+++ b/src/EmulatorConstants.sol
@@ -24,6 +24,8 @@ pragma solidity ^0.8.0;
 library EmulatorConstants {
     // START OF AUTO-GENERATED CODE
 
+    bytes32 constant UARCH_PRISTINE_STATE_HASH =
+        0x1bbf39b2c4324c9c8862b8e5550fe35b06ebccb0dcd2c3f114cc1411813ca5fc;
     uint64 constant UARCH_CYCLE_ADDRESS = 0x400008;
     uint64 constant UARCH_HALT_FLAG_ADDRESS = 0x400000;
     uint64 constant UARCH_PC_ADDRESS = 0x400010;
@@ -33,23 +35,26 @@ library EmulatorConstants {
     uint64 constant UARCH_RAM_START_ADDRESS = 0x600000;
     uint64 constant UARCH_RAM_LENGTH = 0x200000;
     uint64 constant UARCH_STATE_START_ADDRESS = 0x400000;
-    uint8 constant UARCH_STATE_LOG2_SIZE = 22;
-    bytes32 constant UARCH_PRISTINE_STATE_HASH =
-        0x1bbf39b2c4324c9c8862b8e5550fe35b06ebccb0dcd2c3f114cc1411813ca5fc;
     uint64 constant UARCH_ECALL_FN_HALT = 1;
     uint64 constant UARCH_ECALL_FN_PUTCHAR = 2;
     uint64 constant HTIF_YIELD = 0x348;
     uint64 constant IFLAGS_Y_ADDRESS = 0x2f8;
     uint64 constant HTIF_FROMHOST_ADDRESS = 0x330;
-    uint8 constant CMIO_YIELD_REASON_ADVANCE_STATE = 0x0;
+    uint64 constant HTIF_TOHOST_ADDRESS = 0x328;
+    uint64 constant PMA_CMIO_TX_BUFFER_START = 0x60800000;
+    uint64 constant PMA_CMIO_RX_BUFFER_START = 0x60000000;
     uint32 constant TREE_LOG2_WORD_SIZE = 0x5;
     uint32 constant TREE_WORD_SIZE = uint32(1) << TREE_LOG2_WORD_SIZE;
-    uint64 constant PMA_CMIO_RX_BUFFER_START = 0x60000000;
-    uint8 constant PMA_CMIO_RX_BUFFER_LOG2_SIZE = 0x15;
-    uint64 constant PMA_CMIO_TX_BUFFER_START = 0x60800000;
+    uint16 constant CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED = 0x1;
+    uint16 constant CMIO_YIELD_MANUAL_REASON_RX_REJECTED = 0x2;
+    uint16 constant CMIO_YIELD_MANUAL_REASON_TX_EXCEPTION = 0x4;
+    uint8 constant UARCH_STATE_LOG2_SIZE = 22;
     uint8 constant PMA_CMIO_TX_BUFFER_LOG2_SIZE = 0x15;
+    uint8 constant PMA_CMIO_RX_BUFFER_LOG2_SIZE = 0x15;
+    uint8 constant CMIO_YIELD_REASON_ADVANCE_STATE = 0x0;
     // END OF AUTO-GENERATED CODE
 
     uint32 constant IFLAGS_Y_SHIFT = 1;
     uint64 constant LOG2_CYCLES_TO_RESET = 10;
+    uint64 constant checkpointAddress = 0x7ffff000;
 }

--- a/src/EmulatorConstants.sol
+++ b/src/EmulatorConstants.sol
@@ -25,36 +25,47 @@ library EmulatorConstants {
     // START OF AUTO-GENERATED CODE
 
     bytes32 constant UARCH_PRISTINE_STATE_HASH =
-        0x1bbf39b2c4324c9c8862b8e5550fe35b06ebccb0dcd2c3f114cc1411813ca5fc;
+        0xa73214303203557aea4dd151d18244b87f90532fc40e0f25c8795456e33f2b8f;
     uint64 constant UARCH_CYCLE_ADDRESS = 0x400008;
+    uint64 constant UARCH_CYCLE_MAX = 0x100000;
     uint64 constant UARCH_HALT_FLAG_ADDRESS = 0x400000;
     uint64 constant UARCH_PC_ADDRESS = 0x400010;
     uint64 constant UARCH_X0_ADDRESS = 0x400018;
     uint64 constant UARCH_SHADOW_START_ADDRESS = 0x400000;
     uint64 constant UARCH_SHADOW_LENGTH = 0x1000;
+    uint64 constant AR_SHADOW_TLB_START = 0x1000;
+    uint64 constant AR_SHADOW_TLB_LENGTH = 0x6000;
     uint64 constant UARCH_RAM_START_ADDRESS = 0x600000;
     uint64 constant UARCH_RAM_LENGTH = 0x200000;
     uint64 constant UARCH_STATE_START_ADDRESS = 0x400000;
     uint64 constant UARCH_ECALL_FN_HALT = 1;
     uint64 constant UARCH_ECALL_FN_PUTCHAR = 2;
+    uint64 constant UARCH_ECALL_FN_MARK_DIRTY_PAGE = 3;
+    uint64 constant UARCH_ECALL_FN_WRITE_TLB = 4;
     uint64 constant HTIF_YIELD = 0x348;
-    uint64 constant IFLAGS_Y_ADDRESS = 0x2f8;
+    uint64 constant IFLAGS_Y_ADDRESS = 0x300;
     uint64 constant HTIF_FROMHOST_ADDRESS = 0x330;
     uint64 constant HTIF_TOHOST_ADDRESS = 0x328;
-    uint64 constant PMA_CMIO_TX_BUFFER_START = 0x60800000;
-    uint64 constant PMA_CMIO_RX_BUFFER_START = 0x60000000;
+    uint64 constant AR_CMIO_TX_BUFFER_START = 0x60800000;
+    uint64 constant AR_CMIO_RX_BUFFER_START = 0x60000000;
+    uint8 constant AR_CMIO_TX_BUFFER_LOG2_SIZE = 0x15;
+    uint8 constant AR_CMIO_RX_BUFFER_LOG2_SIZE = 0x15;
     uint32 constant TREE_LOG2_WORD_SIZE = 0x5;
     uint32 constant TREE_WORD_SIZE = uint32(1) << TREE_LOG2_WORD_SIZE;
     uint16 constant CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED = 0x1;
     uint16 constant CMIO_YIELD_MANUAL_REASON_RX_REJECTED = 0x2;
     uint16 constant CMIO_YIELD_MANUAL_REASON_TX_EXCEPTION = 0x4;
     uint8 constant UARCH_STATE_LOG2_SIZE = 22;
-    uint8 constant PMA_CMIO_TX_BUFFER_LOG2_SIZE = 0x15;
-    uint8 constant PMA_CMIO_RX_BUFFER_LOG2_SIZE = 0x15;
     uint8 constant CMIO_YIELD_REASON_ADVANCE_STATE = 0x0;
+    uint32 constant HASH_TREE_LOG2_WORD_SIZE = 0x5;
+    uint32 constant HASH_TREE_WORD_SIZE = uint32(1) << HASH_TREE_LOG2_WORD_SIZE;
     // END OF AUTO-GENERATED CODE
 
     uint32 constant IFLAGS_Y_SHIFT = 1;
     uint64 constant LOG2_CYCLES_TO_RESET = 10;
     uint64 constant CHECKPOINT_ADDRESS = 0x7ffff000;
+
+    uint64 constant TLB_SLOT_LENGTH = 32;
+    uint64 constant TLB_SET_SIZE = 256;
+    uint64 constant TLB_SET_LENGTH = TLB_SET_SIZE * TLB_SLOT_LENGTH;
 }

--- a/src/EmulatorConstants.sol
+++ b/src/EmulatorConstants.sol
@@ -56,5 +56,5 @@ library EmulatorConstants {
 
     uint32 constant IFLAGS_Y_SHIFT = 1;
     uint64 constant LOG2_CYCLES_TO_RESET = 10;
-    uint64 constant checkpointAddress = 0x7ffff000;
+    uint64 constant CHECKPOINT_ADDRESS = 0x7ffff000;
 }

--- a/src/SendCmioResponse.sol
+++ b/src/SendCmioResponse.sol
@@ -42,8 +42,10 @@ library SendCmioResponse {
         if (dataLength > 0) {
             // Find the write length: the smallest power of 2 that is >= dataLength and >= tree leaf size
             uint32 writeLengthLog2Size = EmulatorCompat.uint32Log2(dataLength);
-            if (writeLengthLog2Size < EmulatorConstants.TREE_LOG2_WORD_SIZE) {
-                writeLengthLog2Size = EmulatorConstants.TREE_LOG2_WORD_SIZE; // minimum write size is the tree leaf size
+            if (
+                writeLengthLog2Size < EmulatorConstants.HASH_TREE_LOG2_WORD_SIZE
+            ) {
+                writeLengthLog2Size = EmulatorConstants.HASH_TREE_LOG2_WORD_SIZE; // minimum write size is the tree leaf size
             }
             if (
                 EmulatorCompat.uint32ShiftLeft(1, writeLengthLog2Size)
@@ -53,7 +55,7 @@ library SendCmioResponse {
             }
             if (
                 writeLengthLog2Size
-                    > EmulatorConstants.PMA_CMIO_RX_BUFFER_LOG2_SIZE
+                    > EmulatorConstants.AR_CMIO_RX_BUFFER_LOG2_SIZE
             ) {
                 EmulatorCompat.throwRuntimeError(
                     a, "CMIO response data is too large"
@@ -61,12 +63,12 @@ library SendCmioResponse {
             }
             a.writeRegion(
                 Memory.regionFromPhysicalAddress(
-                    EmulatorConstants.PMA_CMIO_RX_BUFFER_START.toPhysicalAddress(
-                    ),
+                    EmulatorConstants.AR_CMIO_RX_BUFFER_START
+                    .toPhysicalAddress(),
                     Memory.alignedSizeFromLog2(
                         uint8(
                             writeLengthLog2Size
-                                - EmulatorConstants.TREE_LOG2_WORD_SIZE
+                                - EmulatorConstants.HASH_TREE_LOG2_WORD_SIZE
                         )
                     )
                 ),

--- a/src/UArchStep.sol
+++ b/src/UArchStep.sol
@@ -30,7 +30,6 @@ library UArchStep {
         Success, // one micro instruction was executed successfully
         CycleOverflow, // already at fixed point: uarch cycle has reached its maximum value
         UArchHalted // already at fixed point: microarchitecture is halted
-
     }
 
     // Memory read/write access
@@ -259,9 +258,9 @@ library UArchStep {
             EmulatorCompat.uint32ShiftLeft(
                 uint32(EmulatorCompat.int32ShiftRight(int32(insn), 25)), 5
             )
-                | EmulatorCompat.uint32ShiftRight(
-                    EmulatorCompat.uint32ShiftLeft(insn, 20), 27
-                )
+            | EmulatorCompat.uint32ShiftRight(
+                EmulatorCompat.uint32ShiftLeft(insn, 20), 27
+            )
         );
     }
 
@@ -574,8 +573,8 @@ library UArchStep {
         uint8 rd = operandRd(insn);
         uint8 rs1 = operandRs1(insn);
         if (rd != 0) {
-            uint64 rs1val = EmulatorCompat.readX(a, rs1);
-            if (int64(rs1val) < imm) {
+            int64 rs1val = int64(EmulatorCompat.readX(a, rs1));
+            if (rs1val < imm) {
                 EmulatorCompat.writeX(a, rd, 1);
             } else {
                 EmulatorCompat.writeX(a, rd, 0);
@@ -1012,7 +1011,7 @@ library UArchStep {
         return advancePc(a, pc);
     }
 
-    function executeFENCE(AccessLogs.Context memory a, uint64 pc)
+    function executeFENCE(AccessLogs.Context memory a, uint32 insn, uint64 pc)
         private
         pure
     {
@@ -1062,24 +1061,48 @@ library UArchStep {
         return advancePc(a, pc);
     }
 
-    function executeECALL(AccessLogs.Context memory a, uint64 pc)
+    function executeECALL(AccessLogs.Context memory a, uint32 insn, uint64 pc)
         private
         pure
     {
+        // ECALL conventions
+        // a0--a7 are the same as x10--x17
+        // syscall is passed in a7
+        // arguments are passed in a0--a5
+        // return value is in a0 (and maybe also in a1)
         uint64 fn = EmulatorCompat.readX(a, 17); // a7 contains the function number
         if (fn == EmulatorConstants.UARCH_ECALL_FN_HALT) {
-            return EmulatorCompat.setHaltFlag(a);
+            return EmulatorCompat.writeHaltFlag(a, 1);
         }
         if (fn == EmulatorConstants.UARCH_ECALL_FN_PUTCHAR) {
-            uint64 character = EmulatorCompat.readX(a, 16); // a6 contains the character to print
-            EmulatorCompat.putChar(a, uint8(character));
-        } else {
-            EmulatorCompat.throwRuntimeError(a, "unsupported ecall function");
+            uint64 c = EmulatorCompat.readX(a, 10); // a0 contains the character to print
+            EmulatorCompat.putCharECALL(a, uint8(c)); // Can be a NOOP in Solidity
+            return advancePc(a, pc);
         }
-        return advancePc(a, pc);
+        if (fn == EmulatorConstants.UARCH_ECALL_FN_MARK_DIRTY_PAGE) {
+            uint64 paddr = EmulatorCompat.readX(a, 10); // a0 contains physical address in page to be marked dirty
+            uint64 pma_index = EmulatorCompat.readX(a, 11); // a1 contains a index of PMA where page falls
+            EmulatorCompat.markDirtyPageECALL(a, paddr, pma_index); // This MUST be be a NOOP in Solidity
+            return advancePc(a, pc);
+        }
+        if (fn == EmulatorConstants.UARCH_ECALL_FN_WRITE_TLB) {
+            uint64 set_index = EmulatorCompat.readX(a, 10); // a0 contains TLB set (code, read, write)
+            uint64 slot_index = EmulatorCompat.readX(a, 11); // a1 contains slot_index to modify
+            uint64 vaddr_page = EmulatorCompat.readX(a, 12); // a2 contains vaddr_page to write
+            uint64 vp_offset = EmulatorCompat.readX(a, 13); // a3 contains vp_offset to write
+            uint64 pma_index = EmulatorCompat.readX(a, 14); // a4 contains index of PMA where page falls
+            EmulatorCompat.writeTlbECALL(
+                a, set_index, slot_index, vaddr_page, vp_offset, pma_index
+            ); // WARNING: This CANNOT be a NOOP in Solidity
+            return advancePc(a, pc);
+        }
+        EmulatorCompat.throwRuntimeError(a, "unsupported ecall function");
     }
 
-    function executeEBREAK(AccessLogs.Context memory a) private pure {
+    function executeEBREAK(AccessLogs.Context memory a, uint32 insn, uint64 pc)
+        private
+        pure
+    {
         EmulatorCompat.throwRuntimeError(a, "uarch aborted");
     }
 
@@ -1099,8 +1122,9 @@ library UArchStep {
         returns (bool)
     {
         uint32 mask = (7 << 12) | 0x7f;
-        return (insn & mask)
-            == (EmulatorCompat.uint32ShiftLeft(funct3, 12) | opcode);
+        return
+            (insn & mask)
+                == (EmulatorCompat.uint32ShiftLeft(funct3, 12) | opcode);
     }
 
     /// \brief Returns true if the opcode, funct3 and funct7 fields of an instruction match the provided arguments
@@ -1112,10 +1136,8 @@ library UArchStep {
     ) private pure returns (bool) {
         uint32 mask = (0x7f << 25) | (7 << 12) | 0x7f;
         return ((insn & mask))
-            == (
-                EmulatorCompat.uint32ShiftLeft(funct7, 25)
-                    | EmulatorCompat.uint32ShiftLeft(funct3, 12) | opcode
-            );
+            == (EmulatorCompat.uint32ShiftLeft(funct7, 25)
+                    | EmulatorCompat.uint32ShiftLeft(funct3, 12) | opcode);
     }
 
     /// \brief Returns true if the opcode, funct3 and 6 most significant bits of funct7 fields of an instruction match the
@@ -1128,10 +1150,8 @@ library UArchStep {
     ) private pure returns (bool) {
         uint32 mask = (0x3f << 26) | (7 << 12) | 0x7f;
         return ((insn & mask))
-            == (
-                EmulatorCompat.uint32ShiftLeft(funct7Sr1, 26)
-                    | EmulatorCompat.uint32ShiftLeft(funct3, 12) | opcode
-            );
+            == (EmulatorCompat.uint32ShiftLeft(funct7Sr1, 26)
+                    | EmulatorCompat.uint32ShiftLeft(funct3, 12) | opcode);
     }
 
     // Decode and execute one instruction
@@ -1287,13 +1307,13 @@ library UArchStep {
             return executeSLTI(a, insn, pc);
         }
         if (insnMatchOpcodeFunct3(insn, 0xf, 0x0)) {
-            return executeFENCE(a, pc);
+            return executeFENCE(a, insn, pc);
         }
         if (insn == uint32(0x73)) {
-            return executeECALL(a, pc);
+            return executeECALL(a, insn, pc);
         }
         if (insn == uint32(0x100073)) {
-            return executeEBREAK(a);
+            return executeEBREAK(a, insn, pc);
         }
         EmulatorCompat.throwRuntimeError(a, "illegal instruction");
     }
@@ -1306,11 +1326,11 @@ library UArchStep {
         // This must be the first read in order to match the first log access in machine.verify_step_uarch
         uint64 cycle = EmulatorCompat.readCycle(a);
         // do not advance if cycle will overflow
-        if (cycle == type(uint64).max) {
+        if (cycle >= EmulatorConstants.UARCH_CYCLE_MAX) {
             return UArchStepStatus.CycleOverflow;
         }
         // do not advance if machine is halted
-        if (EmulatorCompat.readHaltFlag(a)) {
+        if (EmulatorCompat.readHaltFlag(a) != 0) {
             return UArchStepStatus.UArchHalted;
         }
         // execute next instruction
@@ -1327,6 +1347,8 @@ library UArchStep {
     // Explicit instantiation for uarch_record_state_access
 
     // Explicit instantiation for uarch_replay_state_access
+
+    // Explicit instantiation for collect_uarch_cycle_hashes_state_access
 
     // END OF AUTO-GENERATED CODE
 }

--- a/templates/AccessLogs.sol.template
+++ b/templates/AccessLogs.sol.template
@@ -72,15 +72,7 @@ library AccessLogs {
 
         return end2;
     }
-
-    //:#ifndef test
-
-    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
-    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
-
-    //
-    // Read methods
-    //
+    
     function readRegion(
         AccessLogs.Context memory a,
         Memory.Region memory region
@@ -102,32 +94,7 @@ library AccessLogs {
             Memory.regionFromStride(readStride, Memory.alignedSizeFromLog2(0));
         return readRegion(a, r);
     }
-
-    function readWord(
-        AccessLogs.Context memory a,
-        Memory.PhysicalAddress readAddress
-    ) internal pure returns (uint64) {
-        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) =
-            readAddress.truncateToLeaf();
-
-        Memory.Region memory region = Memory.regionFromStride(
-            Memory.strideFromLeafAddress(leafAddress),
-            Memory.alignedSizeFromLog2(0)
-        );
-
-        bytes32 leaf = a.buffer.consumeBytes32();
-        bytes32 rootHash = a.buffer.getRoot(region, keccak256(abi.encodePacked(leaf)));
-        require(
-            a.currentRootHash == rootHash, "Read word root doesn't match"
-        );
-
-        bytes8 word = getBytes8FromBytes32AtOffset(leaf, wordOffset);
-        return machineWordToSolidityUint64(word);
-    }
-
-    //
-    // Write methods
-    //
+    
     function writeRegion(
         AccessLogs.Context memory a,
         Memory.Region memory region,
@@ -154,6 +121,41 @@ library AccessLogs {
             Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(0));
         writeRegion(a, r, newHash);
     }
+
+    //:#ifndef test
+
+    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
+    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
+
+    //
+    // Read methods
+    //
+
+    function readWord(
+        AccessLogs.Context memory a,
+        Memory.PhysicalAddress readAddress
+    ) internal pure returns (uint64) {
+        (Memory.PhysicalAddress leafAddress, uint64 wordOffset) =
+            readAddress.truncateToLeaf();
+
+        Memory.Region memory region = Memory.regionFromStride(
+            Memory.strideFromLeafAddress(leafAddress),
+            Memory.alignedSizeFromLog2(0)
+        );
+
+        bytes32 leaf = a.buffer.consumeBytes32();
+        bytes32 rootHash = a.buffer.getRoot(region, keccak256(abi.encodePacked(leaf)));
+        require(
+            a.currentRootHash == rootHash, "Read word root doesn't match"
+        );
+
+        bytes8 word = getBytes8FromBytes32AtOffset(leaf, wordOffset);
+        return machineWordToSolidityUint64(word);
+    }
+
+    //
+    // Write methods
+    //
 
     function writeWord(
         AccessLogs.Context memory a,
@@ -241,12 +243,6 @@ library AccessLogs {
             mstore(add(data, add(offset, 32)), b32)
         }
     }
-
-    function writeRegion(
-        AccessLogs.Context memory a,
-        Memory.Region memory region,
-        bytes32 newHash
-    ) internal pure {}
 
     function accessWord(
         AccessLogs.Context memory a,

--- a/templates/AccessLogs.sol.template
+++ b/templates/AccessLogs.sol.template
@@ -73,6 +73,76 @@ library AccessLogs {
         return end2;
     }
     
+    function writeRegion(
+        AccessLogs.Context memory a,
+        Memory.Region memory region,
+        bytes32 newHash
+    ) internal pure {
+        bytes32 oldDrive = a.buffer.consumeBytes32();
+        (bytes32 rootHash,) = a.buffer.peekRoot(region, oldDrive);
+        
+        require(
+            a.currentRootHash == rootHash, "Write region root doesn't match"
+        );
+
+        bytes32 newRootHash = a.buffer.getRoot(region, newHash);
+
+        a.currentRootHash = newRootHash;
+    }
+
+    /// @notice Writes 4 64-bit words (32 bytes total) to a single leaf in memory
+    /// @dev This function is specifically designed for writing TLB entries and similar structures
+    function write4Words(
+        AccessLogs.Context memory a,
+        Memory.Stride writeStride,
+        uint64 word0,
+        uint64 word1,
+        uint64 word2,
+        uint64 word3
+    ) internal pure {
+        // Flip endianess and pack data
+        bytes8 w0 = solidityUint64ToMachineWord(word0);
+        bytes8 w1 = solidityUint64ToMachineWord(word1);
+        bytes8 w2 = solidityUint64ToMachineWord(word2);
+        bytes8 w3 = solidityUint64ToMachineWord(word3);
+        bytes32 packed = bytes32(abi.encodePacked(w0, w1, w2, w3));
+
+        // Compute the physical address from stride
+        // For a single leaf, alignedSize = 0, so address = stride << LOG2_LEAF
+        uint64 physicalAddress = Memory.Stride.unwrap(writeStride) << Memory.LOG2_LEAF;
+        Memory.PhysicalAddress paddr = Memory.toPhysicalAddress(physicalAddress);
+
+        // Find the offset in the access log buffer that corresponds to the physical address
+        accessWord(a, paddr);
+        bytes memory data = a.buffer.data;
+        uint256 offset = a.buffer.offset;
+
+        // Update the access log buffer
+        // The 32 is added to offset because we are accessing a byte array.
+        // And an array in solidity always starts with its length which is a 32 byte-long variable.
+        assembly {
+            mstore(add(data, add(offset, 32)), packed)
+        }
+    }
+
+    function writeLeaf(
+        AccessLogs.Context memory a,
+        Memory.Stride writeStride,
+        bytes32 newHash
+    ) internal pure {
+        Memory.Region memory r =
+            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(0));
+        writeRegion(a, r, newHash);
+    }
+
+    //:#ifndef test
+
+    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
+    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
+
+    //
+    // Read methods
+    //
     function readRegion(
         AccessLogs.Context memory a,
         Memory.Region memory region
@@ -94,42 +164,6 @@ library AccessLogs {
             Memory.regionFromStride(readStride, Memory.alignedSizeFromLog2(0));
         return readRegion(a, r);
     }
-    
-    function writeRegion(
-        AccessLogs.Context memory a,
-        Memory.Region memory region,
-        bytes32 newHash
-    ) internal pure {
-        bytes32 oldDrive = a.buffer.consumeBytes32();
-        (bytes32 rootHash,) = a.buffer.peekRoot(region, oldDrive);
-        
-        require(
-            a.currentRootHash == rootHash, "Write region root doesn't match"
-        );
-
-        bytes32 newRootHash = a.buffer.getRoot(region, newHash);
-
-        a.currentRootHash = newRootHash;
-    }
-
-    function writeLeaf(
-        AccessLogs.Context memory a,
-        Memory.Stride writeStride,
-        bytes32 newHash
-    ) internal pure {
-        Memory.Region memory r =
-            Memory.regionFromStride(writeStride, Memory.alignedSizeFromLog2(0));
-        writeRegion(a, r, newHash);
-    }
-
-    //:#ifndef test
-
-    /// @dev bytes buffer layout is the same for `readWord` and `writeWord`,
-    /// [32 bytes as read data], [59 * 32 bytes as sibling hashes]
-
-    //
-    // Read methods
-    //
 
     function readWord(
         AccessLogs.Context memory a,
@@ -207,7 +241,6 @@ library AccessLogs {
         return (leaf & mask) | toWrite;
     }
 
-
     //:#else
 
     /// @dev This library mocks the `templates/AccessLogs.sol` yet with a very different implementation.
@@ -215,6 +248,10 @@ library AccessLogs {
     /// The first 280 bytes are reserved for register space: 0x320 - 0x438 (35 registers * 8 bytes)
     /// Following next will be continuous memory space: 0x70000000 -
 
+    /// `bytes buffer` simulates the memory space with three separate regions.
+    // 1. shadow TLB   (AR_SHADOW_TLB_LENGTH bytes)
+    // 2. shadow UArch (UARCH_SHADOW_LENGTH bytes)
+    // 3. uarch RAM   (rest of the bytes - test binary loaded here)
     function readWord(
         AccessLogs.Context memory a,
         Memory.PhysicalAddress readAddress
@@ -244,6 +281,8 @@ library AccessLogs {
         }
     }
 
+    //:#endif
+
     function accessWord(
         AccessLogs.Context memory a,
         Memory.PhysicalAddress paddr
@@ -251,12 +290,17 @@ library AccessLogs {
         uint64 index;
         uint64 position = Memory.PhysicalAddress.unwrap(paddr);
         if (
+            position >= EmulatorConstants.AR_SHADOW_TLB_START
+                && position <= EmulatorConstants.AR_SHADOW_TLB_START + EmulatorConstants.AR_SHADOW_TLB_LENGTH
+        ) {
+            index = position - EmulatorConstants.AR_SHADOW_TLB_START;
+        } else if (
             position >= EmulatorConstants.UARCH_SHADOW_START_ADDRESS
                 && position <= EmulatorConstants.UARCH_SHADOW_START_ADDRESS + EmulatorConstants.UARCH_SHADOW_LENGTH
         ) {
-            index = (position - EmulatorConstants.UARCH_SHADOW_START_ADDRESS);
+            index = (position - EmulatorConstants.UARCH_SHADOW_START_ADDRESS) + EmulatorConstants.AR_SHADOW_TLB_LENGTH;
         } else if (position >= EmulatorConstants.UARCH_RAM_START_ADDRESS) {
-            index = (position - EmulatorConstants.UARCH_RAM_START_ADDRESS) + (35 << 3);
+            index = (position - EmulatorConstants.UARCH_RAM_START_ADDRESS) + EmulatorConstants.AR_SHADOW_TLB_LENGTH + EmulatorConstants.UARCH_SHADOW_LENGTH;
         } else {
             revert("invalid memory access");
         }
@@ -264,6 +308,4 @@ library AccessLogs {
         a.buffer.offset = index;
         val = a.buffer.peekBytes32();
     }
-
-    //:#endif
 }

--- a/templates/EmulatorConstants.sol.template
+++ b/templates/EmulatorConstants.sol.template
@@ -27,4 +27,5 @@ library EmulatorConstants {
 
     uint32 constant IFLAGS_Y_SHIFT = 1;
     uint64 constant LOG2_CYCLES_TO_RESET = 10;
+    uint64 constant checkpointAddress = 0x7ffff000;
 }

--- a/templates/EmulatorConstants.sol.template
+++ b/templates/EmulatorConstants.sol.template
@@ -27,5 +27,5 @@ library EmulatorConstants {
 
     uint32 constant IFLAGS_Y_SHIFT = 1;
     uint64 constant LOG2_CYCLES_TO_RESET = 10;
-    uint64 constant checkpointAddress = 0x7ffff000;
+    uint64 constant CHECKPOINT_ADDRESS = 0x7ffff000;
 }

--- a/templates/EmulatorConstants.sol.template
+++ b/templates/EmulatorConstants.sol.template
@@ -28,4 +28,8 @@ library EmulatorConstants {
     uint32 constant IFLAGS_Y_SHIFT = 1;
     uint64 constant LOG2_CYCLES_TO_RESET = 10;
     uint64 constant CHECKPOINT_ADDRESS = 0x7ffff000;
+
+    uint64 constant TLB_SLOT_LENGTH = 32;
+    uint64 constant TLB_SET_SIZE = 256;
+    uint64 constant TLB_SET_LENGTH = TLB_SET_SIZE * TLB_SLOT_LENGTH;
 }

--- a/test/AccessLogs.t.sol
+++ b/test/AccessLogs.t.sol
@@ -120,11 +120,12 @@ contract AccessLogsTest is Test {
 
     function testWriteWordBadRegion() public {
         uint64 wordWritten = 3;
-        (Buffer.Context memory buffer, bytes32 rootHash) = makeWriteBuffer(
-            initialReadLeaf,
-            /* withReadValueMismatch= */
-            false
-        );
+        (Buffer.Context memory buffer, bytes32 rootHash) =
+            makeWriteBuffer(
+                initialReadLeaf,
+                /* withReadValueMismatch= */
+                false
+            );
         AccessLogs.Context memory accessLogs =
             AccessLogs.Context(rootHash, buffer);
         vm.expectRevert("Write word root doesn't match");
@@ -197,8 +198,9 @@ contract AccessLogsTest is Test {
         view
         returns (Buffer.Context memory, bytes32)
     {
-        Buffer.Context memory buffer =
-            Buffer.Context(new bytes((59 << Memory.LOG2_LEAF) + 32 + 32), 0);
+        Buffer.Context memory buffer = Buffer.Context(
+            new bytes((59 << Memory.LOG2_LEAF) + 32 + 32), 0
+        );
         bytes32 readData = patchLeaf(initialReadLeaf, readWord, position);
 
         // write leaf data, leaf hash and sibling hashes

--- a/test/Memory.t.sol
+++ b/test/Memory.t.sol
@@ -29,21 +29,21 @@ contract MemoryTest is Test {
     function testStrideAlignment() public {
         for (uint128 paddr = 8; paddr <= (1 << 63); paddr *= 2) {
             for (uint8 l = 0; ((1 << l) <= (paddr >> Memory.LOG2_LEAF)); ++l) {
-                uint64(paddr).toPhysicalAddress().strideFromPhysicalAddress(
-                    Memory.alignedSizeFromLog2(l)
-                );
+                uint64(paddr).toPhysicalAddress()
+                    .strideFromPhysicalAddress(Memory.alignedSizeFromLog2(l));
 
                 // address has to be aligned with 8-byte word
                 vm.expectRevert();
-                uint64(paddr - 1).toPhysicalAddress().strideFromPhysicalAddress(
-                    Memory.alignedSizeFromLog2(l)
-                );
+                uint64(paddr - 1).toPhysicalAddress()
+                    .strideFromPhysicalAddress(Memory.alignedSizeFromLog2(l));
 
                 if ((1 << l) == (paddr >> Memory.LOG2_LEAF)) {
                     // address has to be aligned with stride size
                     vm.expectRevert();
                     uint64(paddr + paddr / 2).toPhysicalAddress()
-                        .strideFromPhysicalAddress(Memory.alignedSizeFromLog2(l));
+                        .strideFromPhysicalAddress(
+                            Memory.alignedSizeFromLog2(l)
+                        );
                 }
             }
         }

--- a/test/SendCmioResponse.t.sol
+++ b/test/SendCmioResponse.t.sol
@@ -70,7 +70,9 @@ contract SendCmioResponse_Test is Test {
         for (uint256 i = 0; i < catalog.length; i++) {
             if (
                 keccak256(abi.encodePacked(catalog[i].logFilename))
-                    != keccak256(abi.encodePacked("send-cmio-response-steps.json"))
+                    != keccak256(
+                        abi.encodePacked("send-cmio-response-steps.json")
+                    )
             ) {
                 continue;
             }
@@ -78,8 +80,9 @@ contract SendCmioResponse_Test is Test {
 
             string memory rj = loadJsonLog(resetLog);
 
-            bytes32 initialRootHash =
-                vm.parseBytes32(string.concat("0x", catalog[i].initialRootHash));
+            bytes32 initialRootHash = vm.parseBytes32(
+                string.concat("0x", catalog[i].initialRootHash)
+            );
             bytes32 finalRootHash =
                 vm.parseBytes32(string.concat("0x", catalog[i].finalRootHash));
 

--- a/test/UArchInterpret.t.sol
+++ b/test/UArchInterpret.t.sol
@@ -87,11 +87,11 @@ contract UArchInterpretTest is Test {
                 uint64(TEST_SUCEEDED)
             );
 
-            bool halt = EmulatorCompat.readHaltFlag(a);
+            bool halt = EmulatorCompat.readHaltFlag(a) != 0;
             assertTrue(halt, "machine should halt");
 
             uint64 cycle = EmulatorCompat.readCycle(a);
-            assertEq(cycle, catalog[i].steps, "cycle values should match");
+            assertEq(catalog[i].steps, cycle, "cycle values should match");
         }
     }
 
@@ -120,7 +120,7 @@ contract UArchInterpretTest is Test {
         // reset cycle to 0
         EmulatorCompat.writeCycle(a, 0);
         // set machine to halt
-        EmulatorCompat.setHaltFlag(a);
+        EmulatorCompat.writeHaltFlag(a, 1);
 
         status = UArchInterpret.interpret(a);
 
@@ -167,9 +167,21 @@ contract UArchInterpretTest is Test {
         pure
         returns (AccessLogs.Context memory)
     {
+        /*
+        Memory layout:
+            - shadow TLB   (AR_SHADOW_TLB_LENGTH bytes)
+            - shadow UArch (UARCH_SHADOW_LENGTH bytes)
+            - uarch RAM   (rest of the bytes - test binary loaded here)
+        */
         return AccessLogs.Context(
             bytes32(0),
-            Buffer.Context(new bytes(uint128(REGISTERS_LENGTH) * 8), 0)
+            Buffer.Context(
+                new bytes(
+                    EmulatorConstants.AR_SHADOW_TLB_LENGTH
+                        + EmulatorConstants.UARCH_SHADOW_LENGTH
+                ),
+                0
+            )
         );
     }
 }

--- a/test/UArchReset.t.sol
+++ b/test/UArchReset.t.sol
@@ -78,8 +78,9 @@ contract UArchReset_Test is Test {
 
             string memory rj = loadJsonLog(resetLog);
 
-            bytes32 initialRootHash =
-                vm.parseBytes32(string.concat("0x", catalog[i].initialRootHash));
+            bytes32 initialRootHash = vm.parseBytes32(
+                string.concat("0x", catalog[i].initialRootHash)
+            );
             bytes32 finalRootHash =
                 vm.parseBytes32(string.concat("0x", catalog[i].finalRootHash));
 


### PR DESCRIPTION
Attempt to rebase: `interpreter-update` on top of `add-checkpoint-primitives`