### PR TITLE
feat!: align Solidity step with persistent cycle-overflow fixed points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed microarchitecture cycle overflow into a state-preserving fixed point derived from `uarch.cycle`
+- Changed microarchitecture cycle overflow to take precedence over halt
+
 ## [0.14.0] - 2026-04-13
 ### Added
 - Added `advanceStatus` to return advance status (accepted, rejected, exception)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOWNLOADDIR := downloads
 SRC_DIR := src
 
 EMULATOR_VERSION ?= v0.21.0
-EMULATOR_TAG ?= -test4
+EMULATOR_TAG ?= -test5
 
 SOLIDITY_VERSION ?= 0.8.30
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOWNLOADDIR := downloads
 SRC_DIR := src
 
 EMULATOR_VERSION ?= v0.21.0
-EMULATOR_TAG ?= -test3
+EMULATOR_TAG ?= -test4
 
 SOLIDITY_VERSION ?= 0.8.30
 

--- a/helper_scripts/generate_EmulatorConstants.lua
+++ b/helper_scripts/generate_EmulatorConstants.lua
@@ -28,8 +28,6 @@ out:write('    uint64 constant ROLLUP_LOG2_MAX_ADVANCE_STATES_PER_EPOCH = ' ..
     cartesi.ROLLUP_LOG2_MAX_ADVANCE_STATES_PER_EPOCH .. ';\n')
 out:write('    uint64 constant UARCH_HALT_ADDRESS = 0x' ..
     hex(cartesi.machine:get_reg_address("uarch_halt")) .. ';\n')
-out:write('    uint64 constant UARCH_HALT_HALTED = ' .. cartesi.UARCH_HALT_HALTED .. ';\n')
-out:write('    uint64 constant UARCH_HALT_CYCLE_OVERFLOW = ' .. cartesi.UARCH_HALT_CYCLE_OVERFLOW .. ';\n')
 out:write('    uint64 constant UARCH_PC_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("uarch_pc")) .. ';\n')
 out:write('    uint64 constant UARCH_X0_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("uarch_x0")) .. ';\n')
 out:write('    uint64 constant UARCH_SHADOW_START_ADDRESS = 0x' .. hex(cartesi.UARCH_SHADOW_START_ADDRESS) .. ';\n')

--- a/helper_scripts/generate_EmulatorConstants.lua
+++ b/helper_scripts/generate_EmulatorConstants.lua
@@ -18,8 +18,18 @@ local out = io.stdout
 out:write('    bytes32 constant UARCH_PRISTINE_STATE_HASH = 0x' .. hexstring(cartesi.UARCH_PRISTINE_STATE_HASH) .. ';\n')
 out:write('    uint64 constant UARCH_CYCLE_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("uarch_cycle")) .. ';\n')
 out:write('    uint64 constant UARCH_CYCLE_MAX = 0x' .. hex(cartesi.UARCH_CYCLE_MAX) .. ';\n')
-out:write('    uint64 constant UARCH_HALT_FLAG_ADDRESS = 0x' ..
-    hex(cartesi.machine:get_reg_address("uarch_halt_flag")) .. ';\n')
+out:write('    uint64 constant ROLLUP_LOG2_MAX_MCYCLES_PER_ADVANCE_STATE = ' ..
+    cartesi.ROLLUP_LOG2_MAX_MCYCLES_PER_ADVANCE_STATE .. ';\n')
+out:write('    uint64 constant ROLLUP_LOG2_MAX_UARCH_CYCLES_PER_MCYCLE = ' ..
+    cartesi.ROLLUP_LOG2_MAX_UARCH_CYCLES_PER_MCYCLE .. ';\n')
+out:write('    uint64 constant ROLLUP_LOG2_MAX_OUTPUT_COUNT = ' ..
+    cartesi.ROLLUP_LOG2_MAX_OUTPUT_COUNT .. ';\n')
+out:write('    uint64 constant ROLLUP_LOG2_MAX_ADVANCE_STATES_PER_EPOCH = ' ..
+    cartesi.ROLLUP_LOG2_MAX_ADVANCE_STATES_PER_EPOCH .. ';\n')
+out:write('    uint64 constant UARCH_HALT_ADDRESS = 0x' ..
+    hex(cartesi.machine:get_reg_address("uarch_halt")) .. ';\n')
+out:write('    uint64 constant UARCH_HALT_HALTED = ' .. cartesi.UARCH_HALT_HALTED .. ';\n')
+out:write('    uint64 constant UARCH_HALT_CYCLE_OVERFLOW = ' .. cartesi.UARCH_HALT_CYCLE_OVERFLOW .. ';\n')
 out:write('    uint64 constant UARCH_PC_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("uarch_pc")) .. ';\n')
 out:write('    uint64 constant UARCH_X0_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("uarch_x0")) .. ';\n')
 out:write('    uint64 constant UARCH_SHADOW_START_ADDRESS = 0x' .. hex(cartesi.UARCH_SHADOW_START_ADDRESS) .. ';\n')
@@ -34,6 +44,9 @@ out:write('    uint64 constant UARCH_ECALL_FN_PUTCHAR = ' .. cartesi.UARCH_ECALL
 out:write('    uint64 constant UARCH_ECALL_FN_WRITE_TLB = ' .. cartesi.UARCH_ECALL_FN_WRITE_TLB .. ';\n')
 out:write('    uint64 constant HTIF_YIELD = 0x' .. hex(cartesi.machine:get_reg_address("htif_iyield")) .. ';\n')
 out:write('    uint64 constant IFLAGS_Y_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("iflags_Y")) .. ';\n')
+out:write('    uint64 constant MCYCLE_ADDRESS = 0x' .. hex(cartesi.machine:get_reg_address("mcycle")) .. ';\n')
+out:write('    uint64 constant IMCYCLEMAX_ADDRESS = 0x' ..
+    hex(cartesi.machine:get_reg_address("imcyclemax")) .. ';\n')
 out:write('    uint64 constant HTIF_FROMHOST_ADDRESS = 0x' ..
     hex(cartesi.machine:get_reg_address("htif_fromhost")) .. ';\n')
 out:write('    uint64 constant HTIF_TOHOST_ADDRESS = 0x' ..

--- a/helper_scripts/generate_UArchStep.sh
+++ b/helper_scripts/generate_UArchStep.sh
@@ -55,7 +55,7 @@ cpp_src=`echo "${BASH_REMATCH[1]}" \
         | $SED -E "s/static inline (\w+) ($INTERNAL_FN)\(([^\n]*)\) \{/function \2\(\3\) internal pure returns \(\1\)\{/g" \
         | $SED -E "s/static inline (\w+) (\w+)\(([^\n]*)\) \{/function \2\(\3\) private pure returns \(\1\)\{/g" \
         | $SED -E "s/($COMPAT_FNS)/EmulatorCompat.\1/g" \
-        | $SED -E "s/([^a-zA-Z])($CONSTANTS)([^a-zA-Z])/EmulatorConstants.\1\2\3/g" \
+        | $SED -E "s/([^a-zA-Z])($CONSTANTS)([^a-zA-Z])/\1EmulatorConstants.\2\3/g" \
         | $SED "s/ returns (void)//g"`
 
 # compose the solidity file from all components

--- a/shasum-download
+++ b/shasum-download
@@ -1,2 +1,2 @@
-28fd67825be2bf53188326065a06f9a5019f7bd07426d21f6053f34e8652fb3e  downloads/machine-emulator-tests-data.deb
-f7d22eacba7c9df62fa6dfa63fe75bdc387f6c7a98f20606bcfd0b01a851830c  downloads/uarch-riscv-tests-json-logs.tar.gz
+fc0090028ceed1e3e7d30e953a20b7d77708b3df705ea8ef9aba1e343997a32b  downloads/machine-emulator-tests-data.deb
+f07140bbd5f1e1279d95fbe6fa31e7a9fc7e00c39eee7205aff9d4abae40fa33  downloads/uarch-riscv-tests-json-logs.tar.gz

--- a/shasum-download
+++ b/shasum-download
@@ -1,2 +1,2 @@
-fc0090028ceed1e3e7d30e953a20b7d77708b3df705ea8ef9aba1e343997a32b  downloads/machine-emulator-tests-data.deb
-f07140bbd5f1e1279d95fbe6fa31e7a9fc7e00c39eee7205aff9d4abae40fa33  downloads/uarch-riscv-tests-json-logs.tar.gz
+182c7a57481daa4076a488b1c3f0b8ba01d0271c267f79c9f5ecb947cac6bd50  downloads/machine-emulator-tests-data.deb
+79e0797c4a30c6a3f2523353006db0b8b99b6a6cdf17670634c6befa024905bf  downloads/uarch-riscv-tests-json-logs.tar.gz

--- a/src/EmulatorCompat.sol
+++ b/src/EmulatorCompat.sol
@@ -61,8 +61,9 @@ library EmulatorCompat {
         pure
         returns (uint64)
     {
-        return
-            a.readWord(EmulatorConstants.UARCH_HALT_ADDRESS.toPhysicalAddress());
+        return a.readWord(
+            EmulatorConstants.UARCH_HALT_ADDRESS.toPhysicalAddress()
+        );
     }
 
     function writeHalt(AccessLogs.Context memory a, uint64 val) internal pure {
@@ -76,8 +77,9 @@ library EmulatorCompat {
         pure
         returns (uint64)
     {
-        return
-            a.readWord(EmulatorConstants.UARCH_PC_ADDRESS.toPhysicalAddress());
+        return a.readWord(
+            EmulatorConstants.UARCH_PC_ADDRESS.toPhysicalAddress()
+        );
     }
 
     function readWord(AccessLogs.Context memory a, uint64 paddr)
@@ -100,10 +102,7 @@ library EmulatorCompat {
         return a.readWord(paddr.toPhysicalAddress());
     }
 
-    function writeCycle(AccessLogs.Context memory a, uint64 val)
-        internal
-        pure
-    {
+    function writeCycle(AccessLogs.Context memory a, uint64 val) internal pure {
         a.writeWord(
             EmulatorConstants.UARCH_CYCLE_ADDRESS.toPhysicalAddress(), val
         );
@@ -160,8 +159,9 @@ library EmulatorCompat {
         pure
         returns (bool)
     {
-        uint64 iflags_y =
-            a.readWord(EmulatorConstants.IFLAGS_Y_ADDRESS.toPhysicalAddress());
+        uint64 iflags_y = a.readWord(
+            EmulatorConstants.IFLAGS_Y_ADDRESS.toPhysicalAddress()
+        );
         if (iflags_y == 0) {
             return false;
         }

--- a/src/EmulatorCompat.sol
+++ b/src/EmulatorCompat.sol
@@ -56,22 +56,18 @@ library EmulatorCompat {
         );
     }
 
-    function readHaltFlag(AccessLogs.Context memory a)
+    function readHalt(AccessLogs.Context memory a)
         internal
         pure
         returns (uint64)
     {
-        return a.readWord(
-            EmulatorConstants.UARCH_HALT_FLAG_ADDRESS.toPhysicalAddress()
-        );
+        return
+            a.readWord(EmulatorConstants.UARCH_HALT_ADDRESS.toPhysicalAddress());
     }
 
-    function writeHaltFlag(AccessLogs.Context memory a, uint64 val)
-        internal
-        pure
-    {
+    function writeHalt(AccessLogs.Context memory a, uint64 val) internal pure {
         a.writeWord(
-            EmulatorConstants.UARCH_HALT_FLAG_ADDRESS.toPhysicalAddress(), val
+            EmulatorConstants.UARCH_HALT_ADDRESS.toPhysicalAddress(), val
         );
     }
 
@@ -80,9 +76,8 @@ library EmulatorCompat {
         pure
         returns (uint64)
     {
-        return a.readWord(
-            EmulatorConstants.UARCH_PC_ADDRESS.toPhysicalAddress()
-        );
+        return
+            a.readWord(EmulatorConstants.UARCH_PC_ADDRESS.toPhysicalAddress());
     }
 
     function readWord(AccessLogs.Context memory a, uint64 paddr)
@@ -105,7 +100,10 @@ library EmulatorCompat {
         return a.readWord(paddr.toPhysicalAddress());
     }
 
-    function writeCycle(AccessLogs.Context memory a, uint64 val) internal pure {
+    function writeCycle(AccessLogs.Context memory a, uint64 val)
+        internal
+        pure
+    {
         a.writeWord(
             EmulatorConstants.UARCH_CYCLE_ADDRESS.toPhysicalAddress(), val
         );
@@ -162,9 +160,8 @@ library EmulatorCompat {
         pure
         returns (bool)
     {
-        uint64 iflags_y = a.readWord(
-            EmulatorConstants.IFLAGS_Y_ADDRESS.toPhysicalAddress()
-        );
+        uint64 iflags_y =
+            a.readWord(EmulatorConstants.IFLAGS_Y_ADDRESS.toPhysicalAddress());
         if (iflags_y == 0) {
             return false;
         }
@@ -176,6 +173,23 @@ library EmulatorCompat {
         pure
     {
         a.writeWord(EmulatorConstants.IFLAGS_Y_ADDRESS.toPhysicalAddress(), val);
+    }
+
+    function readMcycle(AccessLogs.Context memory a)
+        internal
+        pure
+        returns (uint64)
+    {
+        return a.readWord(EmulatorConstants.MCYCLE_ADDRESS.toPhysicalAddress());
+    }
+
+    function writeImcyclemax(AccessLogs.Context memory a, uint64 val)
+        internal
+        pure
+    {
+        a.writeWord(
+            EmulatorConstants.IMCYCLEMAX_ADDRESS.toPhysicalAddress(), val
+        );
     }
 
     function writeHtifFromhost(AccessLogs.Context memory a, uint64 val)

--- a/src/EmulatorConstants.sol
+++ b/src/EmulatorConstants.sol
@@ -25,7 +25,7 @@ library EmulatorConstants {
     // START OF AUTO-GENERATED CODE
 
     bytes32 constant UARCH_PRISTINE_STATE_HASH =
-        0x05dda45cb12872b018f3857a528439b1d1100bcd3fa019a9745ad436de9a4698;
+        0xfecd1447b18725c91ba909a13b3d059d3628a625f668ce991e6ab7c901a65d2c;
     uint64 constant UARCH_CYCLE_ADDRESS = 0x400008;
     uint64 constant UARCH_CYCLE_MAX = 0xfffff;
     uint64 constant ROLLUP_LOG2_MAX_MCYCLES_PER_ADVANCE_STATE = 48;
@@ -33,8 +33,6 @@ library EmulatorConstants {
     uint64 constant ROLLUP_LOG2_MAX_OUTPUT_COUNT = 63;
     uint64 constant ROLLUP_LOG2_MAX_ADVANCE_STATES_PER_EPOCH = 24;
     uint64 constant UARCH_HALT_ADDRESS = 0x400000;
-    uint64 constant UARCH_HALT_HALTED = 1;
-    uint64 constant UARCH_HALT_CYCLE_OVERFLOW = 3;
     uint64 constant UARCH_PC_ADDRESS = 0x400010;
     uint64 constant UARCH_X0_ADDRESS = 0x400018;
     uint64 constant UARCH_SHADOW_START_ADDRESS = 0x400000;

--- a/src/EmulatorConstants.sol
+++ b/src/EmulatorConstants.sol
@@ -25,13 +25,13 @@ library EmulatorConstants {
     // START OF AUTO-GENERATED CODE
 
     bytes32 constant UARCH_PRISTINE_STATE_HASH =
-        0x3be8e5dfc7a97d18e0e36a76a1b44a73a5b187dcbb85e581330f982c8727db97;
+        0x05dda45cb12872b018f3857a528439b1d1100bcd3fa019a9745ad436de9a4698;
     uint64 constant UARCH_CYCLE_ADDRESS = 0x400008;
     uint64 constant UARCH_CYCLE_MAX = 0xfffff;
     uint64 constant ROLLUP_LOG2_MAX_MCYCLES_PER_ADVANCE_STATE = 48;
     uint64 constant ROLLUP_LOG2_MAX_UARCH_CYCLES_PER_MCYCLE = 20;
     uint64 constant ROLLUP_LOG2_MAX_OUTPUT_COUNT = 63;
-    uint64 constant ROLLUP_LOG2_MAX_ADVANCE_STATES_PER_EPOCH = 16;
+    uint64 constant ROLLUP_LOG2_MAX_ADVANCE_STATES_PER_EPOCH = 24;
     uint64 constant UARCH_HALT_ADDRESS = 0x400000;
     uint64 constant UARCH_HALT_HALTED = 1;
     uint64 constant UARCH_HALT_CYCLE_OVERFLOW = 3;

--- a/src/EmulatorConstants.sol
+++ b/src/EmulatorConstants.sol
@@ -25,10 +25,16 @@ library EmulatorConstants {
     // START OF AUTO-GENERATED CODE
 
     bytes32 constant UARCH_PRISTINE_STATE_HASH =
-        0x42e6d54b3b07b4a1c5f2ed13aae7c8d924269c32728a5b66f54b70358b4d99e7;
+        0x3be8e5dfc7a97d18e0e36a76a1b44a73a5b187dcbb85e581330f982c8727db97;
     uint64 constant UARCH_CYCLE_ADDRESS = 0x400008;
-    uint64 constant UARCH_CYCLE_MAX = 0x100000;
-    uint64 constant UARCH_HALT_FLAG_ADDRESS = 0x400000;
+    uint64 constant UARCH_CYCLE_MAX = 0xfffff;
+    uint64 constant ROLLUP_LOG2_MAX_MCYCLES_PER_ADVANCE_STATE = 48;
+    uint64 constant ROLLUP_LOG2_MAX_UARCH_CYCLES_PER_MCYCLE = 20;
+    uint64 constant ROLLUP_LOG2_MAX_OUTPUT_COUNT = 63;
+    uint64 constant ROLLUP_LOG2_MAX_ADVANCE_STATES_PER_EPOCH = 16;
+    uint64 constant UARCH_HALT_ADDRESS = 0x400000;
+    uint64 constant UARCH_HALT_HALTED = 1;
+    uint64 constant UARCH_HALT_CYCLE_OVERFLOW = 3;
     uint64 constant UARCH_PC_ADDRESS = 0x400010;
     uint64 constant UARCH_X0_ADDRESS = 0x400018;
     uint64 constant UARCH_SHADOW_START_ADDRESS = 0x400000;
@@ -41,10 +47,12 @@ library EmulatorConstants {
     uint64 constant UARCH_ECALL_FN_HALT = 1;
     uint64 constant UARCH_ECALL_FN_PUTCHAR = 2;
     uint64 constant UARCH_ECALL_FN_WRITE_TLB = 4;
-    uint64 constant HTIF_YIELD = 0x348;
-    uint64 constant IFLAGS_Y_ADDRESS = 0x300;
-    uint64 constant HTIF_FROMHOST_ADDRESS = 0x330;
-    uint64 constant HTIF_TOHOST_ADDRESS = 0x328;
+    uint64 constant HTIF_YIELD = 0x350;
+    uint64 constant IFLAGS_Y_ADDRESS = 0x308;
+    uint64 constant MCYCLE_ADDRESS = 0x100;
+    uint64 constant IMCYCLEMAX_ADDRESS = 0x2f8;
+    uint64 constant HTIF_FROMHOST_ADDRESS = 0x338;
+    uint64 constant HTIF_TOHOST_ADDRESS = 0x330;
     uint8 constant HTIF_YIELD_REASON_ADVANCE_STATE = 0x0;
     uint32 constant HASH_TREE_LOG2_WORD_SIZE = 0x5;
     uint32 constant HASH_TREE_WORD_SIZE = uint32(1) << HASH_TREE_LOG2_WORD_SIZE;

--- a/src/SendCmioResponse.sol
+++ b/src/SendCmioResponse.sol
@@ -47,10 +47,12 @@ library SendCmioResponse {
             // machine waiting for an input on an rx-accepted manual yield. Sending one to a machine that
             // yielded manual with any other reason (e.g., rejected an input or threw an exception) is a no-op.
             uint64 tohost = EmulatorCompat.readHtifTohost(a);
-            if (!EmulatorCompat.isYieldedManualWith(
+            if (
+                !EmulatorCompat.isYieldedManualWith(
                     tohost,
                     EmulatorConstants.HTIF_YIELD_MANUAL_REASON_RX_ACCEPTED
-                )) {
+                )
+            ) {
                 return;
             }
         }
@@ -78,13 +80,27 @@ library SendCmioResponse {
                 return;
             }
         }
+        if (reason == EmulatorConstants.HTIF_YIELD_REASON_ADVANCE_STATE) {
+            uint64 mcycle = EmulatorCompat.readMcycle(a);
+            uint64 maxMcycles = EmulatorCompat.uint64ShiftLeft(
+                1,
+                uint32(
+                    EmulatorConstants.ROLLUP_LOG2_MAX_MCYCLES_PER_ADVANCE_STATE
+                )
+            ) - 1;
+            uint64 maxUint64 = ~uint64(0);
+            uint64 imcyclemax = mcycle > maxUint64 - maxMcycles
+                ? maxUint64
+                : mcycle + maxMcycles;
+            EmulatorCompat.writeImcyclemax(a, imcyclemax);
+        }
         // Record the machine root hash to revert to in case the response is eventually rejected
         EmulatorCompat.writeRevertRootHash(a, revertRootHash);
         if (dataLength > 0) {
             a.writeRegion(
                 Memory.regionFromPhysicalAddress(
-                    EmulatorConstants.AR_CMIO_RX_BUFFER_START
-                    .toPhysicalAddress(),
+                    EmulatorConstants.AR_CMIO_RX_BUFFER_START.toPhysicalAddress(
+                    ),
                     Memory.alignedSizeFromLog2(
                         uint8(
                             writeLengthLog2Size
@@ -98,9 +114,9 @@ library SendCmioResponse {
         // Write data length and reason to fromhost
         uint64 mask16 = EmulatorCompat.uint64ShiftLeft(1, 16) - 1;
         uint64 mask32 = EmulatorCompat.uint64ShiftLeft(1, 32) - 1;
-        uint64 yieldData =
-            EmulatorCompat.uint64ShiftLeft((uint64(reason) & mask16), 32)
-                | (uint64(dataLength) & mask32);
+        uint64 yieldData = EmulatorCompat.uint64ShiftLeft(
+            (uint64(reason) & mask16), 32
+        ) | (uint64(dataLength) & mask32);
         EmulatorCompat.writeHtifFromhost(a, yieldData);
         // Reset iflags.Y
         EmulatorCompat.writeIflagsY(a, 0);

--- a/src/SendCmioResponse.sol
+++ b/src/SendCmioResponse.sol
@@ -47,12 +47,10 @@ library SendCmioResponse {
             // machine waiting for an input on an rx-accepted manual yield. Sending one to a machine that
             // yielded manual with any other reason (e.g., rejected an input or threw an exception) is a no-op.
             uint64 tohost = EmulatorCompat.readHtifTohost(a);
-            if (
-                !EmulatorCompat.isYieldedManualWith(
+            if (!EmulatorCompat.isYieldedManualWith(
                     tohost,
                     EmulatorConstants.HTIF_YIELD_MANUAL_REASON_RX_ACCEPTED
-                )
-            ) {
+                )) {
                 return;
             }
         }
@@ -82,12 +80,13 @@ library SendCmioResponse {
         }
         if (reason == EmulatorConstants.HTIF_YIELD_REASON_ADVANCE_STATE) {
             uint64 mcycle = EmulatorCompat.readMcycle(a);
-            uint64 maxMcycles = EmulatorCompat.uint64ShiftLeft(
-                1,
-                uint32(
-                    EmulatorConstants.ROLLUP_LOG2_MAX_MCYCLES_PER_ADVANCE_STATE
-                )
-            ) - 1;
+            uint64 maxMcycles =
+                EmulatorCompat.uint64ShiftLeft(
+                        1,
+                        uint32(
+                            EmulatorConstants.ROLLUP_LOG2_MAX_MCYCLES_PER_ADVANCE_STATE
+                        )
+                    ) - 1;
             uint64 maxUint64 = ~uint64(0);
             uint64 imcyclemax = mcycle > maxUint64 - maxMcycles
                 ? maxUint64
@@ -99,8 +98,8 @@ library SendCmioResponse {
         if (dataLength > 0) {
             a.writeRegion(
                 Memory.regionFromPhysicalAddress(
-                    EmulatorConstants.AR_CMIO_RX_BUFFER_START.toPhysicalAddress(
-                    ),
+                    EmulatorConstants.AR_CMIO_RX_BUFFER_START
+                    .toPhysicalAddress(),
                     Memory.alignedSizeFromLog2(
                         uint8(
                             writeLengthLog2Size
@@ -114,9 +113,9 @@ library SendCmioResponse {
         // Write data length and reason to fromhost
         uint64 mask16 = EmulatorCompat.uint64ShiftLeft(1, 16) - 1;
         uint64 mask32 = EmulatorCompat.uint64ShiftLeft(1, 32) - 1;
-        uint64 yieldData = EmulatorCompat.uint64ShiftLeft(
-            (uint64(reason) & mask16), 32
-        ) | (uint64(dataLength) & mask32);
+        uint64 yieldData =
+            EmulatorCompat.uint64ShiftLeft((uint64(reason) & mask16), 32)
+                | (uint64(dataLength) & mask32);
         EmulatorCompat.writeHtifFromhost(a, yieldData);
         // Reset iflags.Y
         EmulatorCompat.writeIflagsY(a, 0);

--- a/src/UArchStep.sol
+++ b/src/UArchStep.sol
@@ -1117,7 +1117,7 @@ library UArchStep {
         pure
         returns (bool)
     {
-        return ((insn & 0x7f)) == opcode;
+        return (insn & 0x7f) == opcode;
     }
 
     /// \brief Returns true if the opcode and funct3 fields of an instruction match the provided arguments
@@ -1140,7 +1140,7 @@ library UArchStep {
         uint32 funct7
     ) private pure returns (bool) {
         uint32 mask = (0x7f << 25) | (7 << 12) | 0x7f;
-        return ((insn & mask))
+        return (insn & mask)
             == (EmulatorCompat.uint32ShiftLeft(funct7, 25)
                     | EmulatorCompat.uint32ShiftLeft(funct3, 12) | opcode);
     }
@@ -1154,7 +1154,7 @@ library UArchStep {
         uint32 funct7Sr1
     ) private pure returns (bool) {
         uint32 mask = (0x3f << 26) | (7 << 12) | 0x7f;
-        return ((insn & mask))
+        return (insn & mask)
             == (EmulatorCompat.uint32ShiftLeft(funct7Sr1, 26)
                     | EmulatorCompat.uint32ShiftLeft(funct3, 12) | opcode);
     }
@@ -1328,12 +1328,12 @@ library UArchStep {
         pure
         returns (UArchStepStatus)
     {
-        // Check and report if already at fixed point
+        // Report existing halt fixed point
         uint64 halt = EmulatorCompat.readHalt(a);
         if (halt != 0) {
             return uarch_halt_to_step_status(halt);
         }
-        // Materialize overflow if the cycle is already at or beyond its limit
+        // Report existing overflow fixed point if the cycle is at or beyond its limit
         uint64 cycle = EmulatorCompat.readCycle(a);
         if (cycle >= EmulatorConstants.UARCH_CYCLE_MAX) {
             EmulatorCompat.writeHalt(
@@ -1355,7 +1355,7 @@ library UArchStep {
             return UArchStepStatus.UArchCycleOverflow;
         }
         // ECALL is the only instruction that can halt the uarch. Overflow was handled above,
-        // so a non-zero halt value here can only report a normal halt; keep the common mapping for consistency.
+        // so a non-zero halt value here can only report a normal halt.
         if (insn == uint32(0x73)) {
             halt = EmulatorCompat.readHalt(a);
             if (halt != 0) {

--- a/src/UArchStep.sol
+++ b/src/UArchStep.sol
@@ -28,8 +28,18 @@ library UArchStep {
 
     enum UArchStepStatus {
         Success, // one micro instruction was executed successfully
-        CycleOverflow, // already at fixed point: uarch cycle has reached its maximum value
-        UArchHalted // already at fixed point: microarchitecture is halted
+        UArchCycleOverflow, // uarch cycle reached or was already at its maximum value
+        UArchHalted // microarchitecture reached or was already at its halted fixed point
+    }
+
+    function uarch_halt_to_step_status(uint64 halt)
+        private
+        pure
+        returns (UArchStepStatus)
+    {
+        return halt == EmulatorConstants.UARCH_HALT_CYCLE_OVERFLOW
+            ? UArchStepStatus.UArchCycleOverflow
+            : UArchStepStatus.UArchHalted;
     }
 
     // Memory read/write access
@@ -1072,7 +1082,8 @@ library UArchStep {
         // return value is in a0 (and maybe also in a1)
         uint64 fn = EmulatorCompat.readX(a, 17); // a7 contains the function number
         if (fn == EmulatorConstants.UARCH_ECALL_FN_HALT) {
-            return EmulatorCompat.writeHaltFlag(a, 1);
+            return
+                EmulatorCompat.writeHalt(a, EmulatorConstants.UARCH_HALT_HALTED);
         }
         if (fn == EmulatorConstants.UARCH_ECALL_FN_PUTCHAR) {
             uint64 c = EmulatorCompat.readX(a, 10); // a0 contains the character to print
@@ -1317,22 +1328,40 @@ library UArchStep {
         pure
         returns (UArchStepStatus)
     {
-        // This must be the first read in order to match the first log access in machine.verify_step_uarch
+        // Check and report if already at fixed point
+        uint64 halt = EmulatorCompat.readHalt(a);
+        if (halt != 0) {
+            return uarch_halt_to_step_status(halt);
+        }
+        // Materialize overflow if the cycle is already at or beyond its limit
         uint64 cycle = EmulatorCompat.readCycle(a);
-        // do not advance if cycle will overflow
         if (cycle >= EmulatorConstants.UARCH_CYCLE_MAX) {
-            return UArchStepStatus.CycleOverflow;
+            EmulatorCompat.writeHalt(
+                a, EmulatorConstants.UARCH_HALT_CYCLE_OVERFLOW
+            );
+            return UArchStepStatus.UArchCycleOverflow;
         }
-        // do not advance if machine is halted
-        if (EmulatorCompat.readHaltFlag(a) != 0) {
-            return UArchStepStatus.UArchHalted;
-        }
-        // execute next instruction
+        // Execute next instruction
         uint64 pc = EmulatorCompat.readPc(a);
         uint32 insn = readUint32(a, pc);
         executeInsn(a, insn, pc);
         cycle = cycle + 1;
         EmulatorCompat.writeCycle(a, cycle);
+        // Materialize overflow immediately when this step reaches the cycle limit
+        if (cycle >= EmulatorConstants.UARCH_CYCLE_MAX) {
+            EmulatorCompat.writeHalt(
+                a, EmulatorConstants.UARCH_HALT_CYCLE_OVERFLOW
+            );
+            return UArchStepStatus.UArchCycleOverflow;
+        }
+        // ECALL is the only instruction that can halt the uarch. Overflow was handled above,
+        // so a non-zero halt value here can only report a normal halt; keep the common mapping for consistency.
+        if (insn == uint32(0x73)) {
+            halt = EmulatorCompat.readHalt(a);
+            if (halt != 0) {
+                return uarch_halt_to_step_status(halt);
+            }
+        }
         return UArchStepStatus.Success;
     }
 

--- a/src/UArchStep.sol
+++ b/src/UArchStep.sol
@@ -32,16 +32,6 @@ library UArchStep {
         UArchHalted // microarchitecture reached or was already at its halted fixed point
     }
 
-    function uarch_halt_to_step_status(uint64 halt)
-        private
-        pure
-        returns (UArchStepStatus)
-    {
-        return halt == EmulatorConstants.UARCH_HALT_CYCLE_OVERFLOW
-            ? UArchStepStatus.UArchCycleOverflow
-            : UArchStepStatus.UArchHalted;
-    }
-
     // Memory read/write access
 
     function readUint64(AccessLogs.Context memory a, uint64 paddr)
@@ -1082,8 +1072,7 @@ library UArchStep {
         // return value is in a0 (and maybe also in a1)
         uint64 fn = EmulatorCompat.readX(a, 17); // a7 contains the function number
         if (fn == EmulatorConstants.UARCH_ECALL_FN_HALT) {
-            return
-                EmulatorCompat.writeHalt(a, EmulatorConstants.UARCH_HALT_HALTED);
+            return EmulatorCompat.writeHalt(a, 1);
         }
         if (fn == EmulatorConstants.UARCH_ECALL_FN_PUTCHAR) {
             uint64 c = EmulatorCompat.readX(a, 10); // a0 contains the character to print
@@ -1328,18 +1317,14 @@ library UArchStep {
         pure
         returns (UArchStepStatus)
     {
-        // Report existing halt fixed point
-        uint64 halt = EmulatorCompat.readHalt(a);
-        if (halt != 0) {
-            return uarch_halt_to_step_status(halt);
-        }
-        // Report existing overflow fixed point if the cycle is at or beyond its limit
+        // Report the derived overflow fixed point before all other break reasons.
         uint64 cycle = EmulatorCompat.readCycle(a);
         if (cycle >= EmulatorConstants.UARCH_CYCLE_MAX) {
-            EmulatorCompat.writeHalt(
-                a, EmulatorConstants.UARCH_HALT_CYCLE_OVERFLOW
-            );
             return UArchStepStatus.UArchCycleOverflow;
+        }
+        // Report an existing ordinary halt fixed point.
+        if (EmulatorCompat.readHalt(a) != 0) {
+            return UArchStepStatus.UArchHalted;
         }
         // Execute next instruction
         uint64 pc = EmulatorCompat.readPc(a);
@@ -1347,19 +1332,14 @@ library UArchStep {
         executeInsn(a, insn, pc);
         cycle = cycle + 1;
         EmulatorCompat.writeCycle(a, cycle);
-        // Materialize overflow immediately when this step reaches the cycle limit
+        // Overflow has precedence when this step reaches the cycle limit.
         if (cycle >= EmulatorConstants.UARCH_CYCLE_MAX) {
-            EmulatorCompat.writeHalt(
-                a, EmulatorConstants.UARCH_HALT_CYCLE_OVERFLOW
-            );
             return UArchStepStatus.UArchCycleOverflow;
         }
-        // ECALL is the only instruction that can halt the uarch. Overflow was handled above,
-        // so a non-zero halt value here can only report a normal halt.
+        // ECALL is the only instruction that can halt the uarch.
         if (insn == uint32(0x73)) {
-            halt = EmulatorCompat.readHalt(a);
-            if (halt != 0) {
-                return uarch_halt_to_step_status(halt);
+            if (EmulatorCompat.readHalt(a) != 0) {
+                return UArchStepStatus.UArchHalted;
             }
         }
         return UArchStepStatus.Success;

--- a/test/SendCmioResponse.t.sol
+++ b/test/SendCmioResponse.t.sol
@@ -88,7 +88,7 @@ contract SendCmioResponse_Test is AccessLogJsonParse {
 
             // Prepare arguments for sendCmioResponse
             // These values are hard-coded in order to match the values used when generating the test log file
-            uint16 reason = 1;
+            uint16 reason = EmulatorConstants.HTIF_YIELD_REASON_ADVANCE_STATE;
             bytes memory response = bytes("This is a test cmio response");
             require(
                 response.length == 28,

--- a/test/UArchInterpret.sol
+++ b/test/UArchInterpret.sol
@@ -28,7 +28,7 @@ library UArchInterpret {
     {
         UArchStep.UArchStepStatus status;
 
-        while (status != UArchStep.UArchStepStatus.CycleOverflow) {
+        while (status != UArchStep.UArchStepStatus.UArchCycleOverflow) {
             status = UArchStep.step(accessLogs);
 
             if (status == UArchStep.UArchStepStatus.UArchHalted) {

--- a/test/UArchInterpret.t.sol
+++ b/test/UArchInterpret.t.sol
@@ -86,7 +86,7 @@ contract UArchInterpretTest is Test {
                 uint64(TEST_SUCCEEDED)
             );
 
-            bool halt = EmulatorCompat.readHaltFlag(a) != 0;
+            bool halt = EmulatorCompat.readHalt(a) != 0;
             assertTrue(halt, "machine should halt");
 
             uint64 cycle = EmulatorCompat.readCycle(a);
@@ -99,27 +99,32 @@ contract UArchInterpretTest is Test {
 
         // init pc to ram start
         EmulatorCompat.writePc(a, EmulatorConstants.UARCH_RAM_START_ADDRESS);
-        // init cycle to uint64.max
-        EmulatorCompat.writeCycle(a, type(uint64).max);
+        // init cycle to the final allowed uarch cycle
+        EmulatorCompat.writeCycle(a, EmulatorConstants.UARCH_CYCLE_MAX);
 
         UArchStep.UArchStepStatus status = UArchInterpret.interpret(a);
 
         assertTrue(
-            status == UArchStep.UArchStepStatus.CycleOverflow,
+            status == UArchStep.UArchStepStatus.UArchCycleOverflow,
             "machine should be cycle overflow"
         );
 
         uint64 cycle = EmulatorCompat.readCycle(a);
         assertEq(
             cycle,
-            type(uint64).max,
-            "step should not advance when cycle is uint64.max"
+            EmulatorConstants.UARCH_CYCLE_MAX,
+            "step should not advance when cycle is at its maximum"
+        );
+        assertEq(
+            EmulatorCompat.readHalt(a),
+            EmulatorConstants.UARCH_HALT_CYCLE_OVERFLOW,
+            "halt flag should record cycle overflow"
         );
 
         // reset cycle to 0
         EmulatorCompat.writeCycle(a, 0);
         // set machine to halt
-        EmulatorCompat.writeHaltFlag(a, 1);
+        EmulatorCompat.writeHalt(a, EmulatorConstants.UARCH_HALT_HALTED);
 
         status = UArchInterpret.interpret(a);
 

--- a/test/UArchInterpret.t.sol
+++ b/test/UArchInterpret.t.sol
@@ -115,16 +115,12 @@ contract UArchInterpretTest is Test {
             EmulatorConstants.UARCH_CYCLE_MAX,
             "step should not advance when cycle is at its maximum"
         );
-        assertEq(
-            EmulatorCompat.readHalt(a),
-            EmulatorConstants.UARCH_HALT_CYCLE_OVERFLOW,
-            "halt flag should record cycle overflow"
-        );
+        assertEq(EmulatorCompat.readHalt(a), 0, "overflow should preserve halt");
 
         // reset cycle to 0
         EmulatorCompat.writeCycle(a, 0);
         // set machine to halt
-        EmulatorCompat.writeHalt(a, EmulatorConstants.UARCH_HALT_HALTED);
+        EmulatorCompat.writeHalt(a, 1);
 
         status = UArchInterpret.interpret(a);
 
@@ -132,6 +128,17 @@ contract UArchInterpretTest is Test {
             status == UArchStep.UArchStepStatus.UArchHalted,
             "machine should halt"
         );
+
+        // overflow takes precedence over halt
+        EmulatorCompat.writeCycle(a, EmulatorConstants.UARCH_CYCLE_MAX);
+
+        status = UArchInterpret.interpret(a);
+
+        assertTrue(
+            status == UArchStep.UArchStepStatus.UArchCycleOverflow,
+            "machine should be cycle overflow"
+        );
+        assertEq(EmulatorCompat.readHalt(a), 1, "overflow should preserve halt");
     }
 
     function testIllegalInstruction() public {
@@ -144,6 +151,34 @@ contract UArchInterpretTest is Test {
 
         vm.expectRevert("illegal instruction");
         ExternalUArchInterpret.interpret(a);
+    }
+
+    function testHaltEcallReachesCycleLimit() public {
+        AccessLogs.Context memory a = newAccessLogsContext();
+        a.buffer.data = bytes.concat(a.buffer.data, new bytes(8));
+
+        EmulatorCompat.writePc(a, EmulatorConstants.UARCH_RAM_START_ADDRESS);
+        EmulatorCompat.writeWord(
+            a, EmulatorConstants.UARCH_RAM_START_ADDRESS, 0x73
+        );
+        EmulatorCompat.writeX(a, 17, EmulatorConstants.UARCH_ECALL_FN_HALT);
+        EmulatorCompat.writeCycle(a, EmulatorConstants.UARCH_CYCLE_MAX - 1);
+
+        UArchStep.UArchStepStatus status = UArchStep.step(a);
+
+        assertTrue(
+            status == UArchStep.UArchStepStatus.UArchCycleOverflow,
+            "cycle overflow should take precedence over halt"
+        );
+        assertEq(
+            EmulatorCompat.readCycle(a),
+            EmulatorConstants.UARCH_CYCLE_MAX,
+            "step should reach the cycle limit"
+        );
+        assertTrue(
+            EmulatorCompat.readHalt(a) != 0,
+            "halt ECALL should set a non-zero halt value"
+        );
     }
 
     function testRemovedMarkDirtyPageEcall() public {


### PR DESCRIPTION
## Problem

  The Solidity transition did not match the emulator’s new fixed-point semantics. Cycle overflow was not persisted in the
  uarch halt register, and the transition could not distinguish normal halt from overflow.

  ## Solution

  This PR aligns `machine-solidity-step` with the emulator:

  - Regenerates `UArchStep.sol` from the updated C++ transition.
  - Persists normal halt and cycle-overflow reasons in `uarch.halt`.
  - Returns `UArchCycleOverflow` when the cycle reaches its limit.
  - Adds the new uarch halt and rollup constants.
  - Sets `imcyclemax` when accepting an advance-state response.
  - Updates the compatibility layer and generator scripts.
  - Adds tests for halted and cycle-overflow fixed points.

  The generated step now reads `uarch.halt` first, avoids execution at a fixed point, and materializes overflow
  immediately after reaching the cycle limit.
